### PR TITLE
[Feat] Entity의 날짜 @EntityListeners 사용하도록 수정

### DIFF
--- a/src/main/java/com/sj/Petory/config/JpaAuditingConfig.java
+++ b/src/main/java/com/sj/Petory/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.sj.Petory.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/sj/Petory/domain/member/entity/Member.java
+++ b/src/main/java/com/sj/Petory/domain/member/entity/Member.java
@@ -4,11 +4,13 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 
     @Id
@@ -31,7 +33,7 @@ public class Member {
     private String image;
 
     @CreatedDate
-    @Column
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
Member Entity의 cratedAt 과 updatedAt이 @EntityListeners 를 사용하여 자동으로 값을 받을 수 있게 하였습니다.  
이를 위해 config 패키지에 JpaAuditingConfig 클래스를 만들어 @Configuration,  @EnableJpaAuditing을 붙여줘야 합니다.

SpringApplication위에 @EnableJpaAuditing을 붙여줘도 정상 동작을 하지만 테스트 시 모든 테스트가 항상 Jpa 관련 빈을 필요로 해서 문제가 발생하기 때문에 따로 클래스를 구성하였습니다. 
(@WebMvcTest(Xxx.class) 는 JPA 관련 빈들을 로드하지 않기 때문에 문제가 발생합니다.)

**TO-BE**
회원가입 유효성 로직 작성
테스트 코드 작성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [O] API 테스트 
