### PR TITLE
[Feat] 예외처리를 위한 클래스 구성

### DIFF
--- a/src/main/java/com/sj/Petory/exception/CustomException.java
+++ b/src/main/java/com/sj/Petory/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.sj.Petory.exception;
+
+import com.sj.Petory.exception.type.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sj/Petory/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sj/Petory/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.sj.Petory.exception;
+
+import com.sj.Petory.domain.member.controller.MemberController;
+import com.sj.Petory.exception.dto.ErrorResponse;
+import com.sj.Petory.exception.type.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.sj.Petory.exception.type.ErrorCode.INTERNAL_SERVER_ERROR;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(
+            Exception e) {
+
+        log.error("{} : {}", e.getClass().getName(), e.getMessage());
+
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ErrorResponse.from(e, INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(
+            CustomException e) {
+
+        log.error("{} : {}", e.getClass().getName(), e.getErrorCode().getDescription());
+
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResponse.from(e));
+    }
+}

--- a/src/main/java/com/sj/Petory/exception/MemberException.java
+++ b/src/main/java/com/sj/Petory/exception/MemberException.java
@@ -1,0 +1,11 @@
+package com.sj.Petory.exception;
+
+import com.sj.Petory.exception.type.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class MemberException extends CustomException{
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/sj/Petory/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/sj/Petory/exception/dto/ErrorResponse.java
@@ -1,0 +1,36 @@
+package com.sj.Petory.exception.dto;
+
+import com.sj.Petory.exception.CustomException;
+import com.sj.Petory.exception.type.ErrorCode;
+import lombok.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorResponse {
+    private ErrorCode errorCode;
+    private String errorMessage;
+    private HttpStatus httpStatus;
+
+    public static ErrorResponse from(
+            final Exception e, final ErrorCode errorCode) {
+
+        return ErrorResponse.builder()
+                .errorCode(errorCode)
+                .errorMessage(e.getMessage())
+                .httpStatus(errorCode.getHttpStatus())
+                .build();
+    }
+
+    public static ErrorResponse from(final CustomException e) {
+        return ErrorResponse.builder()
+                .errorCode(e.getErrorCode())
+                .errorMessage(e.getErrorCode().getDescription())
+                .httpStatus(e.getErrorCode().getHttpStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
+++ b/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.sj.Petory.exception.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    EMAIL_DUPLICATED("중복된 이메일입니다.",HttpStatus.BAD_REQUEST);
+
+    private final String description;
+    private final HttpStatus httpStatus;
+}
+


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
ErrorCode : enum 클래스로 예외의 설명을 기술할 description, Http상태 코드를 기술할 HttpStatus를 함께 선언합니다.

ErrorResponse : 예외처리 메소드들에서 일관된 응답을 내려주기 위한 dto 클래스 입니다.

GlobalExceptionHandler : 클래스에 @RestControllerAdvice를 붙여 RestController에서 발생한 예외들을 처리할 수 있게 하였고 안에는 @ExceptionHandler(XxxException.class)를 붙인 메소드들을 두어 각각의 Exception이 발생했을 때 처리할 수 있는 메소드를 정의하였습니다.

   @ExceptionHandler(CustomException.class) 가 붙은 메소드들
   : ResponseEntity<ErrorResponse>로 응답하여 HttpStatus 코드와 함께 일관된 응답을 해줄 수 있도록 하였습니다.
      응답값은 rerturn ResponseEntity.status(e.getErrorCode().getHttpStatus()) 
                                                     .body(ErrorResponse.from(~~));
                               로 ErrorCode enum 클래스에서 작성한 httpStatus 코드를 응답해주고
                                   ErrorResponse안에 from메소드를 작성해 ErrorResponse의 모든 필드를 일관된 응답으로 전송할 수 있게 하 
                                    였습니다.

CustomException : RuntimeException을 상속받은 클래스로 모든 XxxException의 부모가 될 클래스 입니다.
 안에는 ErrorCode를 필드로 두고 생성자를 만들어서 모든 XxxException클래스에서 반복되어야 할 코드를 줄여줍니다.

MemberException : 현재 개발 중인 회원관련 API에서 발생한 예외들을 처리해줄 클래스 입니다. 
 CustomException을 상속받고 생성자로 super(errorCode)를 두어 발생한 ErrorCode를 생성자를 이용해 초기화해줍니다.


**TO-BE**


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [O] API 테스트 
