### PR TITLE
[Test] 회원가입 성공/실패 테스트 (RerstDocs + Swagger 미적용)

### DIFF
--- a/src/test/java/com/sj/Petory/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/sj/Petory/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,84 @@
+package com.sj.Petory.domain.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sj.Petory.domain.member.dto.SignUp;
+import com.sj.Petory.domain.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    void signupSuccessTest() throws Exception {
+        //given
+        SignUp.Request request =
+                SignUp.Request.builder()
+                        .name("박소은")
+                        .email("test@naver.com")
+                        .password("abcd12345!")
+                        .phone("010-1111-1111")
+                        .image("imageURL")
+                        .build();
+
+        //when
+        given(memberService.signUp(any()))
+                .willReturn(true);
+
+        //then
+        mockMvc.perform(post("/members")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(String.valueOf(true)));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트")
+    void signupFailTest() throws Exception {
+        //given
+        SignUp.Request request =
+                SignUp.Request.builder()
+                        .name("박소은")
+                        .email("test@naver.com")
+                        .password("abcd12345!")
+                        .phone("010-1111-1111")
+                        .image("imageURL")
+                        .build();
+
+        //when
+        given(memberService.signUp(any()))
+                .willReturn(false);
+
+        //then
+        mockMvc.perform(post("/members")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(String.valueOf(false)));
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
@WebMvcTest(XxxController.class)를 이용해 MemberController에 대한 테스트 코드를 작성하였습니다.

ObjectMapper로 객체 직렬화를 할 수 있게 하였습니다.

mockMvc.perform() 메소드의 .content를 이용해서 필요한 @ResponseBody를 넣어줄 수 있도록 하였고
.contentType()을 이용해 Request의 타입을 JSON으로 명시하였습니다.
응답값은 json형식이 아닌 boolean 값 자체기 때문에 content().string(String.valueOf(true/false))로 boolean의 문자열 그대로를 검사하였습니다.
아직 RestDocs와 Swagger는 적용되지 않은 상태입니다.

**TO-BE**
RestDocs , Swagger 적용해서 리팩토링

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [O] 테스트 코드
- [ ] API 테스트 
