### PR TITLE
[Fix] 회원가입 유효성 로직 추가

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
@@ -12,8 +12,13 @@ import org.springframework.stereotype.Service;
 public class MemberService {
     private final MemberRepository memberRepository;
 
-    public Boolean signUp(SignUp.Request request) {
+    public boolean signUp(SignUp.Request request) {
+
+        checkEmailDuplicate(request.getEmail());
+        checkNameDuplicate(request.getName());
+
         memberRepository.save(request.toEntity());
+
         return true;
     }
 

--- a/src/test/java/com/sj/Petory/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/sj/Petory/domain/member/controller/MemberControllerTest.java
@@ -7,27 +7,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sj.Petory.domain.member.dto.SignUp;
 import com.sj.Petory.domain.member.service.MemberService;
 import com.sj.Petory.exception.MemberException;
-import com.sj.Petory.exception.dto.ErrorResponse;
-import com.sj.Petory.exception.type.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.sj.Petory.exception.type.ErrorCode.EMAIL_DUPLICATED;
 import static com.sj.Petory.exception.type.ErrorCode.NAME_DUPLICATED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -220,8 +215,6 @@ class MemberControllerTest {
                 .andDo(MockMvcRestDocumentationWrapper.document("/members/check-email/fail",
                         ResourceSnippetParameters.builder()
                                 .tag("Member API")
-                                .summary("Email Duplicate Check Fail API")
-                                .description("이메일 중복체크 API")
                                 .responseSchema(Schema.schema("ErrorResponse"))
                                 .responseHeaders(
                                         headerWithName("Code").defaultValue(400)
@@ -282,8 +275,6 @@ class MemberControllerTest {
                 .andDo(MockMvcRestDocumentationWrapper.document("/members/check-name/fail",
                         ResourceSnippetParameters.builder()
                                 .tag("Member API")
-                                .summary("Name Duplicate Check Fail API")
-                                .description("이름 중복체크 API")
                                 .responseSchema(Schema.schema("ErrorResponse"))
                                 .responseHeaders(
                                         headerWithName("Code").defaultValue(400)

--- a/src/test/java/com/sj/Petory/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/sj/Petory/domain/member/controller/MemberControllerTest.java
@@ -7,32 +7,35 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sj.Petory.domain.member.dto.SignUp;
 import com.sj.Petory.domain.member.service.MemberService;
 import com.sj.Petory.exception.MemberException;
+import com.sj.Petory.exception.dto.ErrorResponse;
+import com.sj.Petory.exception.type.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.sj.Petory.exception.type.ErrorCode.EMAIL_DUPLICATED;
+import static com.sj.Petory.exception.type.ErrorCode.NAME_DUPLICATED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(MemberController.class)
 @AutoConfigureRestDocs
@@ -48,17 +51,10 @@ class MemberControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
-    @DisplayName("회원가입 성공 테스트")
+    @DisplayName("회원가입 성공")
     void signupSuccessTest() throws Exception {
         //given
-        SignUp.Request request =
-                SignUp.Request.builder()
-                        .name("박소은")
-                        .email("test@naver.com")
-                        .password("abcd12345!")
-                        .phone("010-1111-1111")
-                        .image("imageURL")
-                        .build();
+        SignUp.Request request = getRequest();
 
         //when
         given(memberService.signUp(any()))
@@ -89,42 +85,96 @@ class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("회원가입 실패 테스트")
-    void signupFailTest() throws Exception {
+    @DisplayName("회원가입 실패- 이메일 중복")
+    void signupFail_EmailDuplicated() throws Exception {
         //given
-        SignUp.Request request =
-                SignUp.Request.builder()
-                        .name("박소은")
-                        .email("test@naver.com")
-                        .password("abcd12345!")
-                        .phone("010-1111-1111")
-                        .image("imageURL")
-                        .build();
+        SignUp.Request request = getRequest();
 
         //when
         given(memberService.signUp(any()))
-                .willReturn(false);
+                .willThrow(new MemberException(EMAIL_DUPLICATED));
 
         //then
         mockMvc.perform(post("/members")
+                        .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string(String.valueOf(false)))
-                .andDo(document("/members/signup-fail",
-                        resource(
-                                ResourceSnippetParameters.builder()
-                                        .tag("Member API")
-                                        .description("Member request Error")
-                                        .summary("회원가입 API")
-                                        .build()
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("EMAIL_DUPLICATED"))
+                .andExpect(jsonPath("$.errorMessage").value("중복된 이메일입니다."))
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andDo(document("/members/signup-fail-emailDuplicated",
+                        ResourceSnippetParameters.builder()
+                                .tag("Member API")
+                                .summary("Member request API")
+                                .description("회원가입 API")
+                                .requestSchema(Schema.schema("SignUp.Request"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                        , preprocessRequest(prettyPrint())
+                        , preprocessResponse(prettyPrint())
+                        , requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
+                                , fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+                                , fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                                , fieldWithPath("phone").type(JsonFieldType.STRING).description("전화번호")
+                                , fieldWithPath("image").type(JsonFieldType.STRING).description("이미지 경로")
+                        )
+                        , responseFields(
+                                fieldWithPath("errorCode").type(JsonFieldType.STRING).description("에러 코드")
+                                , fieldWithPath("errorMessage").type(JsonFieldType.STRING).description("에러 메세지")
+                                , fieldWithPath("httpStatus").type(JsonFieldType.STRING).description("http 상태코드")
+
                         )
                 ));
     }
 
     @Test
-    @DisplayName("이메일 중복체크 성공테스트")
+    @DisplayName("회원가입 실패 테스트 - 이름 중복")
+    void signupFail_NameDuplicated() throws Exception {
+        //given
+        SignUp.Request request = getRequest();
+
+        //when
+        given(memberService.signUp(any()))
+                .willThrow(new MemberException(NAME_DUPLICATED));
+
+        //then
+        mockMvc.perform(post("/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("NAME_DUPLICATED"))
+                .andExpect(jsonPath("$.errorMessage").value("중복된 이름입니다."))
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andDo(document("/members/signup-fail-NameDuplicated",
+                        ResourceSnippetParameters.builder()
+                                .tag("Member API")
+                                .summary("Member request API")
+                                .description("회원가입 API")
+                                .requestSchema(Schema.schema("SignUp.Request"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                        , preprocessRequest(prettyPrint())
+                        , preprocessResponse(prettyPrint())
+                        , requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
+                                , fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
+                                , fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                                , fieldWithPath("phone").type(JsonFieldType.STRING).description("전화번호")
+                                , fieldWithPath("image").type(JsonFieldType.STRING).description("이미지 경로")
+                        )
+                        , responseFields(
+                                fieldWithPath("errorCode").type(JsonFieldType.STRING).description("에러 코드")
+                                , fieldWithPath("errorMessage").type(JsonFieldType.STRING).description("에러 메세지")
+                                , fieldWithPath("httpStatus").type(JsonFieldType.STRING).description("http 상태코드")
+
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("이메일 중복체크 성공")
     void checkEmailSuccessTest() throws Exception {
         //given
         String email = "test@naver.com";
@@ -151,16 +201,15 @@ class MemberControllerTest {
                 );
     }
 
-
     @Test
-    @DisplayName("이메일 중복체크 실패 테스트 - 이메일 중복")
+    @DisplayName("이메일 중복체크 실패")
     void checkEmailFailTest() throws Exception {
         //given
         String email = "test@naver.com";
 
         //when
-        doThrow(new MemberException(EMAIL_DUPLICATED))
-                .when(memberService).checkEmailDuplicate(email);
+        given(memberService.checkEmailDuplicate(email))
+                .willThrow(new MemberException(EMAIL_DUPLICATED));
 
         //then
         mockMvc.perform(get("/members/check-email")
@@ -168,16 +217,96 @@ class MemberControllerTest {
                 .andExpect(
                         status().isBadRequest())
                 .andDo(print())
-                .andDo(MockMvcRestDocumentationWrapper.document("/members/check-email",
+                .andDo(MockMvcRestDocumentationWrapper.document("/members/check-email/fail",
                         ResourceSnippetParameters.builder()
-                                .tag("Member")
-                                .summary("Member API")
+                                .tag("Member API")
+                                .summary("Email Duplicate Check Fail API")
                                 .description("이메일 중복체크 API")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .responseHeaders(
+                                        headerWithName("Code").defaultValue(400)
+                                )
+                        , queryParameters(
+                                parameterWithName("email").description("이메일")
+                        )
                         , responseFields(
                                 fieldWithPath("errorCode").description("에러 코드")
                                 , fieldWithPath("errorMessage").description("에러 메세지")
                                 , fieldWithPath("httpStatus").description("상태 코드")
                         )));
     }
-}
 
+    @Test
+    @DisplayName("이름 중복체크 성공")
+    void checkNameSuccessTest() throws Exception {
+        //given
+        String name = "박소은";
+
+        //when
+        given(memberService.checkNameDuplicate(name))
+                .willReturn(true);
+
+        //then
+        mockMvc.perform(get("/members/check-name")
+                        .queryParam("name", name))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(content().string(String.valueOf(true)))
+                .andDo(document("/members/check-name",
+                        ResourceSnippetParameters.builder()
+                                .tag("Member API")
+                                .summary("Name Duplicate Check API")
+                                .description("이름 중복체크 API")
+                        , queryParameters(
+                                parameterWithName("name").description("이름")
+                        ))
+                );
+    }
+
+    @Test
+    @DisplayName("이름 중복체크 실패")
+    void checkNameFailTest() throws Exception {
+        //given
+        String name = "박소은";
+
+        //when
+        given(memberService.checkNameDuplicate(name))
+                .willThrow(new MemberException(NAME_DUPLICATED));
+
+        //then
+        mockMvc.perform(get("/members/check-name")
+                        .queryParam("name", name))
+                .andExpect(
+                        status().isBadRequest())
+                .andDo(print())
+                .andDo(MockMvcRestDocumentationWrapper.document("/members/check-name/fail",
+                        ResourceSnippetParameters.builder()
+                                .tag("Member API")
+                                .summary("Name Duplicate Check Fail API")
+                                .description("이름 중복체크 API")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .responseHeaders(
+                                        headerWithName("Code").defaultValue(400)
+                                )
+                        , queryParameters(
+                                parameterWithName("name").description("이름")
+                        )
+                        , responseFields(
+                                fieldWithPath("errorCode").description("에러 코드")
+                                , fieldWithPath("errorMessage").description("에러 메세지")
+                                , fieldWithPath("httpStatus").description("상태 코드")
+                        )));
+    }
+
+    private SignUp.Request getRequest() {
+        SignUp.Request request =
+                SignUp.Request.builder()
+                        .name("박소은")
+                        .email("test@naver.com")
+                        .password("abcd12345!")
+                        .phone("010-1111-1111")
+                        .image("imageURL")
+                        .build();
+        return request;
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
이메일, 이름 중복 체크 컨트롤러가 따로 있지만 중복이 되어도 프론트에서 개발자도구로 회원가입 버튼을 활성화하면 중복된 회원이 가입되는 것을 확인하였습니다.
이에 회원가입 서비스 레이어에 중복확인하는 로직을 추가하였습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
