### PR TITLE
[Feat] SpringSecurity 설정

### DIFF
--- a/src/main/java/com/sj/Petory/config/SecurityConfig.java
+++ b/src/main/java/com/sj/Petory/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.sj.Petory.config;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((authz) ->
+                        authz
+                                .requestMatchers(
+                                        "/members"
+                                        , "/members/check-email"
+                                        , "/members/check-name"
+                                        , "members/login"
+                                        , "/h2-console/**").permitAll()
+                                .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
SecurityConfig 클래스 파일을 만들어
csrf, httpBasic, FormLogin 설정을 비활성화 해주고
authorizeHttpRequest안에 requestMatchers로 security를 적용하지 않을 URI는 permitAll() 설정을,
그 외 나머지에는 authticated()로 인증이 필요하도록 설정했습니다.

**TO-BE**
로그인 API 현

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
