### PR TITLE
[Feat] 토큰 인증 로직, 필터로 요청 시마다 토큰 검증로직 작성

### DIFF
--- a/src/main/java/com/sj/Petory/config/SecurityConfig.java
+++ b/src/main/java/com/sj/Petory/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.sj.Petory.config;
 
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import com.sj.Petory.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -10,13 +12,16 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-
-import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
@@ -46,7 +51,10 @@ public class SecurityConfig {
                                         , "/h2-console/**"
                                         , "/docs/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                                 .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);  // JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 전에 추가
+
+        ;
 
         return http.build();
     }

--- a/src/main/java/com/sj/Petory/domain/member/dto/MemberAdapter.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/MemberAdapter.java
@@ -1,0 +1,54 @@
+package com.sj.Petory.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class MemberAdapter implements UserDetails{
+
+    private final String email;
+    private final String password;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/sj/Petory/domain/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/MemberInfoResponse.java
@@ -1,0 +1,22 @@
+package com.sj.Petory.domain.member.dto;
+
+import com.sj.Petory.domain.member.entity.Member;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberInfoResponse {
+    private String name;
+    private String phone;
+    private String image;
+
+    public static MemberInfoResponse fromEntity(Member member) {
+        return MemberInfoResponse.builder()
+                .name(member.getName())
+                .phone(member.getPhone())
+                .build();
+    }
+}

--- a/src/main/java/com/sj/Petory/domain/member/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/UserDetailsServiceImpl.java
@@ -1,0 +1,29 @@
+package com.sj.Petory.domain.member.service;
+
+import com.sj.Petory.domain.member.dto.MemberAdapter;
+import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.member.repository.MemberRepository;
+import com.sj.Petory.exception.MemberException;
+import com.sj.Petory.exception.type.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+
+        return new MemberAdapter(member.getEmail(), member.getPassword());
+    }
+}

--- a/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
+++ b/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     EMAIL_DUPLICATED("중복된 이메일입니다.", HttpStatus.BAD_REQUEST),
     NAME_DUPLICATED("중복된 이름입니다.", HttpStatus.BAD_REQUEST),
     MEMBER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-    PASSWORD_UNMATCHED("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+    PASSWORD_UNMATCHED("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    TOKEN_EXPIRED("만료된 토큰입니다.", HttpStatus.BAD_REQUEST);
 
     private final String description;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sj/Petory/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sj/Petory/security/JwtAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package com.sj.Petory.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token = jwtUtils.resolveToken(request);
+        System.out.println(token);
+        if (StringUtils.hasText(token) && jwtUtils.validateToken(token)) {
+            Authentication authentication = jwtUtils.getAuthentication(token);
+            System.out.println(authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info(String.valueOf(SecurityContextHolder.getContext().getAuthentication()));
+        }
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- JwtAuthenticationFilter
  헤더에서 토큰 뽑아오는 JwtUtils메소드 호출
  Authentication을 가져오는 로직
  SecurityContextHolder에 Authentication 등록

- JwtUtils
 resolveToken() : 헤더로부터 토큰 가져오는 메소드
 validateToken() : 토큰 유효한지 확인 메소드
 parseClaims(), parseEmail() : 토큰에서 Claims를 파싱하고 Claims에서 Email을 파싱하는 메소드
 getAuthentication() : UserDetails.loadUserByUsername() 메소드를 이용해 UsernamePasswordAuthenticationToken을 이용해 Authentication을 반환하는 메소드

**TO-BE**
코드 리팩토링
유효성 조건 확실히
토큰 만료 시 에외 응답 처리
RefreshToken Redis에 저장

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
