### PR TITLE
[Feat] 회원정보 수정 API 구현

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sj/Petory/domain/member/controller/MemberController.java
@@ -78,6 +78,16 @@ public class MemberController {
                         memberAdapter, pageable));
     }
 
+    @PatchMapping
+    public ResponseEntity<Boolean> updateMember(
+            @AuthenticationPrincipal MemberAdapter memberAdapter
+            , @RequestBody UpdateMemberRequest request) {
+
+        return ResponseEntity.ok(
+                memberService.updateMember(
+                        memberAdapter, request));
+    }
+
     @GetMapping("/test")
     public String test() {
         return "hello";

--- a/src/main/java/com/sj/Petory/domain/member/dto/UpdateMemberRequest.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/UpdateMemberRequest.java
@@ -1,0 +1,15 @@
+package com.sj.Petory.domain.member.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateMemberRequest {
+
+    private String name;
+    private String password;
+    private String image;
+}

--- a/src/main/java/com/sj/Petory/domain/member/entity/Member.java
+++ b/src/main/java/com/sj/Petory/domain/member/entity/Member.java
@@ -1,14 +1,17 @@
 package com.sj.Petory.domain.member.entity;
 
+import com.sj.Petory.domain.member.dto.UpdateMemberRequest;
 import com.sj.Petory.domain.member.type.MemberStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -18,6 +21,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@DynamicUpdate
 public class Member {
 
     @Id
@@ -50,4 +54,18 @@ public class Member {
     @LastModifiedDate
     @Column
     private LocalDateTime updatedAt;
+
+    public Member updateInfo(final UpdateMemberRequest request) {
+        if (StringUtils.hasText(request.getName())) {
+            this.name = request.getName();
+        }
+        if (StringUtils.hasText(request.getPassword())) {
+            this.password = request.getPassword();
+        }
+        if (StringUtils.hasText(request.getImage())) {
+            this.image = request.getImage();
+        }
+
+        return this;
+    }
 }

--- a/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
@@ -13,8 +13,11 @@ import com.sj.Petory.security.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -100,5 +103,20 @@ public class MemberService {
         return postRepository.findByMember(
                 getMemberByEmail(memberAdapter.getEmail()), pageable)
                 .map(Post::toDto);
+    }
+
+    @Transactional
+    public boolean updateMember(final MemberAdapter memberAdapter, final UpdateMemberRequest request) {
+        Member member = getMemberByEmail(memberAdapter.getEmail());
+
+        checkNameDuplicate(request.getName());
+
+        if (StringUtils.hasText(request.getPassword())) {
+            request.setPassword(
+                    passwordEncoder.encode(request.getPassword()));
+        }
+        member.updateInfo(request);
+
+        return true;
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
회원정보 수정 API를 구현하였습니다.
엔티티에 @DynamicUpdate를 붙이고 회원정보 수정 서비스 메소드에 @Transactional을 사용하여 더티체킹으로 엔티티에 변경이 생겼을 때 수정 사항을 반영하였습니다.

또한 Member entity 전체의 필드를 변경할 것이 아니기 때문에 PUT 대신 PATCH를 사용하였고
비밀번호를 변경할 시 다시 PasswordEncoder를 사용한 암호화 로직을 넣어 구현하였습니다.
**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
