### PR TITLE
[Feat] 카카오 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+    //webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+
 }
 
 task copySecret(type: Copy) {

--- a/src/main/java/com/sj/Petory/OAuth/KakaoLogin.java
+++ b/src/main/java/com/sj/Petory/OAuth/KakaoLogin.java
@@ -1,0 +1,22 @@
+package com.sj.Petory.OAuth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class KakaoLogin {
+    private final KakaoLoginService kakaoLoginService;
+
+    @GetMapping("/oauth/kakao/callback")//인가코드 발급
+    public ResponseEntity<?> callbackKakao(@RequestParam("code") String code) {
+
+        System.out.println(code);
+        kakaoLoginService.getAccessTokenFromKakao(code);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/sj/Petory/OAuth/KakaoLoginService.java
+++ b/src/main/java/com/sj/Petory/OAuth/KakaoLoginService.java
@@ -1,0 +1,57 @@
+package com.sj.Petory.OAuth;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class KakaoLoginService {
+
+    private String clientId;
+    private final String KAUTH_TOKEN_URL_HOST;
+    private final String KAUTH_USER_URL_HOST;
+
+    @Autowired
+    public KakaoLoginService(@Value("${kakao.client_id}") String clientId) {
+        this.clientId = clientId;
+        KAUTH_TOKEN_URL_HOST ="https://kauth.kakao.com";
+        KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+    }
+
+    public String getAccessTokenFromKakao(String code) {
+
+        KakaoTokenResponse kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL_HOST).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO : Custom Exception
+//                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+//                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(KakaoTokenResponse.class)
+                .block();
+
+
+        log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
+        log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
+        //제공 조건: OpenID Connect가 활성화 된 앱의 토큰 발급 요청인 경우 또는 scope에 openid를 포함한 추가 항목 동의 받기 요청을 거친 토큰 발급 요청인 경우
+        log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDto.getIdToken());
+        log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDto.getScope());
+
+        return kakaoTokenResponseDto.getAccessToken();
+    }
+}

--- a/src/main/java/com/sj/Petory/OAuth/KakaoTokenResponse.java
+++ b/src/main/java/com/sj/Petory/OAuth/KakaoTokenResponse.java
@@ -1,0 +1,33 @@
+package com.sj.Petory.OAuth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    public String tokenType;
+
+    @JsonProperty("access_token")
+    public String accessToken;
+
+    @JsonProperty("id_token")
+    public String idToken;
+
+    @JsonProperty("expires_in")
+    public String expiresIn;
+
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    public String refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    public String scope;
+}

--- a/src/main/java/com/sj/Petory/config/SecurityConfig.java
+++ b/src/main/java/com/sj/Petory/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                                         , "members/login"
                                         , "/h2-console/**"
                                         , "/docs/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                                .requestMatchers("/oauth/kakao/callback").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);  // JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 전에 추가


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
카카오 소셜 로그인을 1차적으로 구현하였습니다.
redirectURL로 들어오는 code를 통해 카카오 서버로 POST 요청을 보내 토큰을 발급 받습니다.
해당 POST 요청은 service에서 요청하게 되며 이때 Webflux 의존성을 이용해 URl builder로 요청을 보냅니다.

**TO-BE**
토큰에서 사용자 정보 불러와서 중복 체크 후 DB에 저장
필요한 정보 더 입력 받도록 로직 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
