### PR TITLE
[Feat] 카카오 로그인 토큰으로 사용자 정보 받아와서 저장하는 로직 현

### DIFF
--- a/src/main/java/com/sj/Petory/OAuth/KakaoExtraUserInfo.java
+++ b/src/main/java/com/sj/Petory/OAuth/KakaoExtraUserInfo.java
@@ -1,0 +1,14 @@
+package com.sj.Petory.OAuth;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoExtraUserInfo {
+    private String email;
+    private String phone;
+}

--- a/src/main/java/com/sj/Petory/OAuth/KakaoLoginController.java
+++ b/src/main/java/com/sj/Petory/OAuth/KakaoLoginController.java
@@ -9,14 +9,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class KakaoLogin {
+public class KakaoLoginController {
     private final KakaoLoginService kakaoLoginService;
 
     @GetMapping("/oauth/kakao/callback")//인가코드 발급
     public ResponseEntity<?> callbackKakao(@RequestParam("code") String code) {
 
         System.out.println(code);
-        kakaoLoginService.getAccessTokenFromKakao(code);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok(kakaoLoginService.getAccessTokenFromKakao(code));
+
     }
 }

--- a/src/main/java/com/sj/Petory/OAuth/UserInfoResponse.java
+++ b/src/main/java/com/sj/Petory/OAuth/UserInfoResponse.java
@@ -1,0 +1,49 @@
+package com.sj.Petory.OAuth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserInfoResponse {
+    @JsonProperty("id")
+    private long id;
+
+    @JsonProperty("properties")
+    private HashMap<String, String> properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAcount kakaoAcount;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAcount {
+
+        @JsonProperty("profile")
+        public ProfileInfo profile;
+
+        @JsonProperty("profile_nickname_needs_agreement")
+        public boolean nickNameAgree;
+
+        @JsonProperty("profile_image_needs_agreement")
+        public boolean profileImageAgree;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class ProfileInfo {
+
+            @JsonProperty("nickname")
+            public String nickName;
+
+            @JsonProperty("profile_image_url")
+            public String profileImageUrl;
+        }
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
프론트에서 카카오 서버로 로그인을 요청하여 받아온 인가코드를
백 컨트롤러에서 지정한 리다이렉트 URL로 받습니다.
백의 서비스 단에 전달된 코드로 카카오 서버에 토큰을 요청합니다.
토큰을 통해 DB에 같은 이메일로 가입된 사용자가 있는지 찾고 있으면 해당 회원을 반환, 없으면 새 Member Entity를 생성해 DB에 저장합니다.

응답으로는 일반 로그인과 똑같이 ATK와 RTK를 생성해 반환하게 됩니다. 

**TO-BE**
추가 정보 실제 사용자에게 받도록 수정해야함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
