### PR TITLE
[Fix] flyway 오류 해결

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/entity/Member.java
+++ b/src/main/java/com/sj/Petory/domain/member/entity/Member.java
@@ -26,33 +26,34 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "member_id")
+    private Long memberId;
 
-    @Column
+    @Column(name = "name")
     private String name;
 
-    @Column
+    @Column(name = "email")
     private String email;
 
-    @Column
+    @Column(name = "password")
     private String password;
 
-    @Column
+    @Column(name = "phone")
     private String phone;
 
-    @Column
+    @Column(name = "image")
     private String image;
 
-    @Column
+    @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     public Member updateInfo(final UpdateMemberRequest request) {

--- a/src/main/java/com/sj/Petory/domain/postcategory/entity/PostCategory.java
+++ b/src/main/java/com/sj/Petory/domain/postcategory/entity/PostCategory.java
@@ -1,5 +1,6 @@
 package com.sj.Petory.domain.postcategory.entity;
 
+import com.sj.Petory.domain.member.entity.Member;
 import com.sj.Petory.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.*;
@@ -14,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
+@Table(name = "postcategory")
 public class PostCategory {
 
     @Id

--- a/src/main/resources/db/migration/mariaDB/V2__alter_pet_age.sql
+++ b/src/main/resources/db/migration/mariaDB/V2__alter_pet_age.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pet MODIFY pet_age BIGINT;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
missing table오류 해결을 위해 RDS 파라미터 그룹에서 lower_case_table_names 옵션을 대소문자 구분하지 않는 옵션인 1로 변경해주었습니다.
테이블을 다 밀고 다시 생성해주어 기존 Member 와 같은 카멜 케이스로 생성되던 테이블이 member와 같이 싹다 소문자로 생성되게 되었고 따라서 jpa가 엔티티를 통해 테이블에 접근할 때 missing table 오류를 해결했습니다.

또한 post_category 와 같이 테이블을 찾으려고 할 때 실제 flyway가 만든 테이블 명은 postcategory 형식이어서 PostCategory 엔티티 클래스 위에 @Table(name = "postcategory")와 같이 붙여주어 엔티티와 실제 테이블이 매핑되도록 하였습니다.

초기 V1__init_table.sql 스크립트를 통해 테이블을 생성한 후에는 ddl-auto 옵션을 none에서 validate로 변경하여 엔티티와 실제 테이블 간 매핑이 되지 않는 오류를 감지할 수 있게 하였습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
