### PR TITLE
[Fix] 카카오 로그인 최초 실행 시 member 저장에 status도 저장하도록 수정

### DIFF
--- a/src/main/java/com/sj/Petory/OAuth/service/KakaoLoginService.java
+++ b/src/main/java/com/sj/Petory/OAuth/service/KakaoLoginService.java
@@ -7,6 +7,7 @@ import com.sj.Petory.common.s3.AmazonS3Service;
 import com.sj.Petory.domain.member.dto.SignIn;
 import com.sj.Petory.domain.member.entity.Member;
 import com.sj.Petory.domain.member.repository.MemberRepository;
+import com.sj.Petory.domain.member.type.MemberStatus;
 import com.sj.Petory.security.JwtUtils;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
@@ -106,6 +107,7 @@ public class KakaoLoginService {
                 .phone(extraUserInfo.getPhone())
                 .image(amazonS3Service.uploadImageforKakao(
                         profile.getProfileImageUrl()))
+                .status(MemberStatus.ACTIVE)
                 .build();
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
카카오 로그인 최초 실행 시 DB에 사용자가 없을 경우 사용자를 생성해서 저장해주게 되는데 이 때 status를 ACTIVE로 저장하는 부분이 누락되어 수정했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
