### PR TITLE
[Fix] 요청이 쌓였을 때 대비 레포지토리 조회 형태 변경

### DIFF
--- a/src/main/java/com/sj/Petory/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/sj/Petory/domain/friend/repository/FriendRepository.java
@@ -10,12 +10,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FriendRepository extends JpaRepository<FriendInfo, Long> {
 
-    Optional<FriendInfo> findBySendMemberAndReceiveMember(Member member, Member friend);
+    List<FriendInfo> findBySendMemberAndReceiveMember(Member member, Member friend);
 
     Optional<FriendInfo> findBySendMemberAndReceiveMemberAndFriendStatus(
             Member member, Member friend, FriendStatus friendStatus);

--- a/src/main/java/com/sj/Petory/domain/friend/service/FriendService.java
+++ b/src/main/java/com/sj/Petory/domain/friend/service/FriendService.java
@@ -57,36 +57,35 @@ public class FriendService {
         Member sendMember = getMemberByEmail(memberAdapter.getEmail());
         Member receiveMember = getMemberById(friendId);
 
-        if (validateFriendRequest(sendMember, receiveMember)) {
-            friendRepository.save(
-                    FriendInfo.friendRequestToEntity(sendMember, receiveMember));
-        }
+        validateFriendRequest(sendMember, receiveMember);
+
+        friendRepository.save(
+                FriendInfo.friendRequestToEntity(sendMember, receiveMember));
 
         return true;
     }
 
-    private boolean validateFriendRequest(Member member, Member friend) {
-        if (member.equals(friend)) {
+    private void validateFriendRequest(Member sendMember, Member receiveMember) {
+        if (sendMember.equals(receiveMember)) {
             throw new FriendException(ErrorCode.REQUEST_MYSELF_NOT_ALLOWED);
         }
-        friendRepository.findBySendMemberAndReceiveMember(
-                        member, friend)
-                .ifPresent(info -> {
+
+        friendRepository.findBySendMemberAndReceiveMember(sendMember, receiveMember)
+                .forEach(info -> {
                     if (info.getFriendStatus().getFriendStatusId() == 1) {
                         throw new FriendException(ErrorCode.ALREADY_FRIEND_REQUEST);
-                    } else if (info.getFriendStatus().getFriendStatusId() == 2) {
+                    }
+                    if (info.getFriendStatus().getFriendStatusId() == 2) {
                         throw new FriendException(ErrorCode.ALREADY_FRIEND_MEMBER);
                     }
                 });
-        friendRepository.findBySendMemberAndReceiveMember(
-                        friend, member)
-                .ifPresent(info -> {
+
+        friendRepository.findBySendMemberAndReceiveMember(receiveMember, sendMember)
+                .forEach(info -> {
                     if (info.getFriendStatus().getFriendStatusId() == 1) {
                         throw new FriendException(ErrorCode.ALREADY_RECEIVE_FRIEND_REQUEST);
                     }
                 });
-
-        return true;
     }
 
     private Member getMemberByEmail(String email) {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
sendMember와 receiveMember로 DB에서 조회해오는 레포지토리 메소드의 반환형이 optional이라 거절, 친구 상태가 쌓였을 때 친구 요청을 한 번 더 보내면 500 에러가 발생하여 로직을 List형태로 반환하는 것으로 수정하였습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
