### PR TITLE
[Fix] 회원의 반려동물 조회 시 세부 정보도 함께 내려가도록 수정

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/controller/MemberController.java
+++ b/src/main/java/com/sj/Petory/domain/member/controller/MemberController.java
@@ -24,14 +24,6 @@ public class MemberController {
                 memberService.signUp(request));
     }
 
-    @PatchMapping("/image")
-    public ResponseEntity<?> s3ImageUpload(
-            @AuthenticationPrincipal MemberAdapter memberAdapter
-            , @RequestPart(value = "image", required = false) MultipartFile image) {
-
-        return ResponseEntity.ok(memberService.imageUpload(memberAdapter, image));
-    }
-
     @GetMapping("/check-email")
     public ResponseEntity<Boolean> checkEmailDuplicate(
             @RequestParam("email") String email) {
@@ -84,6 +76,14 @@ public class MemberController {
                         memberAdapter, pageable));
     }
 
+    @PatchMapping("/image")
+    public ResponseEntity<?> s3ImageUpload(
+            @AuthenticationPrincipal MemberAdapter memberAdapter
+            , @RequestPart(value = "image", required = false) MultipartFile image) {
+
+        return ResponseEntity.ok(memberService.imageUpload(memberAdapter, image));
+    }
+
     @PatchMapping
     public ResponseEntity<Boolean> updateMember(
             @AuthenticationPrincipal MemberAdapter memberAdapter
@@ -100,10 +100,5 @@ public class MemberController {
 
         return ResponseEntity.ok(
                 memberService.deleteMember(memberAdapter));
-    }
-
-    @GetMapping("/test")
-    public String test() {
-        return "hello";
     }
 }

--- a/src/main/java/com/sj/Petory/domain/member/dto/PetResponse.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/PetResponse.java
@@ -1,6 +1,7 @@
 package com.sj.Petory.domain.member.dto;
 
 import com.sj.Petory.domain.pet.entity.Pet;
+import com.sj.Petory.domain.pet.type.PetGender;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -15,6 +16,11 @@ public class PetResponse {
     private String name;
     private String image;
 
+    private String species;
+    private String breed;
+    private long age;
+    private PetGender gender;
+    private String memo;
 
 
 }

--- a/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
@@ -5,8 +5,12 @@ import com.sj.Petory.domain.member.dto.*;
 import com.sj.Petory.domain.member.entity.Member;
 import com.sj.Petory.domain.member.repository.MemberRepository;
 import com.sj.Petory.domain.member.type.MemberStatus;
+import com.sj.Petory.domain.pet.entity.Breed;
 import com.sj.Petory.domain.pet.entity.Pet;
+import com.sj.Petory.domain.pet.entity.Species;
+import com.sj.Petory.domain.pet.repository.BreedRepository;
 import com.sj.Petory.domain.pet.repository.PetRepository;
+import com.sj.Petory.domain.pet.repository.SpeciesRepository;
 import com.sj.Petory.domain.post.entity.Post;
 import com.sj.Petory.domain.post.repository.PostRepository;
 import com.sj.Petory.exception.MemberException;
@@ -21,12 +25,16 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PetRepository petRepository;
     private final PostRepository postRepository;
+    private final SpeciesRepository speciesRepository;
+    private final BreedRepository breedRepository;
 
 //    private final MemberElasticsearchRepository memberElasticsearchRepository;
 
@@ -99,7 +107,8 @@ public class MemberService {
         Member member = getMemberByEmail(memberAdapter.getEmail());
 
         return petRepository.findByMember(member, pageable)
-                .map(Pet::toDto);
+                .map(pet -> pet.toDto(
+                        breedRepository.findByBreedId(pet.getBreed())));
     }
 
     public Page<PostResponse> getMembersPosts(

--- a/src/main/java/com/sj/Petory/domain/pet/dto/PetRegister.java
+++ b/src/main/java/com/sj/Petory/domain/pet/dto/PetRegister.java
@@ -1,10 +1,10 @@
 package com.sj.Petory.domain.pet.dto;
 
 import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.pet.entity.Breed;
 import com.sj.Petory.domain.pet.entity.Pet;
-import com.sj.Petory.domain.pet.type.PetBreed;
+import com.sj.Petory.domain.pet.entity.Species;
 import com.sj.Petory.domain.pet.type.PetGender;
-import com.sj.Petory.domain.pet.type.PetSpecies;
 import com.sj.Petory.domain.pet.type.PetStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,11 +19,11 @@ public class PetRegister {
     @Builder
     public static class Request {
 
-        @NotBlank
-        private String species;
+        @NotNull
+        private long speciesId;
 
-        @NotBlank
-        private String breed;
+        @NotNull
+        private long breedId;
 
         @NotBlank
         private String name;
@@ -37,12 +37,16 @@ public class PetRegister {
         private String image;
         private String memo;
 
-        public Pet toEntity(Member member) {
+        public Pet toEntity(
+                final Member member
+                , final Species species
+                , final Breed breed) {
+
             return Pet.builder()
                     .member(member)
                     .petName(this.getName())
-                    .species(PetSpecies.valueOf(this.getSpecies()))
-                    .breed(PetBreed.valueOf(this.getBreed()))
+                    .species(species)
+                    .breed(breed.getBreedId())
                     .petGender(PetGender.valueOf(this.getGender()))
                     .petAge(this.getAge())
                     .petImage(this.getImage())

--- a/src/main/java/com/sj/Petory/domain/pet/entity/Breed.java
+++ b/src/main/java/com/sj/Petory/domain/pet/entity/Breed.java
@@ -1,0 +1,27 @@
+package com.sj.Petory.domain.pet.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Breed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "breed_id")
+    private Long breedId;
+
+    @ManyToOne
+    @JoinColumn(name = "species_id")
+    private Species species;
+
+    @Column(name = "breed_name")
+    private String breedName;
+}

--- a/src/main/java/com/sj/Petory/domain/pet/entity/Pet.java
+++ b/src/main/java/com/sj/Petory/domain/pet/entity/Pet.java
@@ -2,10 +2,7 @@ package com.sj.Petory.domain.pet.entity;
 
 import com.sj.Petory.domain.member.dto.PetResponse;
 import com.sj.Petory.domain.member.entity.Member;
-import com.sj.Petory.domain.pet.dto.PetRegister;
-import com.sj.Petory.domain.pet.type.PetBreed;
 import com.sj.Petory.domain.pet.type.PetGender;
-import com.sj.Petory.domain.pet.type.PetSpecies;
 import com.sj.Petory.domain.pet.type.PetStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -37,22 +34,21 @@ public class Pet {
     @Column
     private String petName;
 
-    @Column
-    @Enumerated(EnumType.STRING)
-    private PetSpecies species;
+    @ManyToOne
+    @JoinColumn(name = "species_id")
+    private Species species;
 
-    @Column
-    @Enumerated(EnumType.STRING)
-    private PetBreed breed;
+    @Column(name = "breed_id")
+    private Long breed;
 
-    @Column
+    @Column(name = "pet_gender")
     @Enumerated(EnumType.STRING)
     private PetGender petGender;
 
     @Column
     private Long petAge;
 
-    @Column
+    @Column(name = "pet_image")
     private String petImage;
 
     @Column
@@ -70,11 +66,16 @@ public class Pet {
     @Column
     private LocalDateTime updatedAt;
 
-    public PetResponse toDto() {
+    public PetResponse toDto(Breed breed) {
         return PetResponse.builder()
                 .petId(this.getPetId())
                 .name(this.getPetName())
                 .image(this.getPetImage())
+                .species(this.getSpecies().getSpeciesName())
+                .breed(breed.getBreedName())
+                .age(this.getPetAge())
+                .gender(this.getPetGender())
+                .memo(this.getMemo())
                 .build();
     }
 }

--- a/src/main/java/com/sj/Petory/domain/pet/entity/Species.java
+++ b/src/main/java/com/sj/Petory/domain/pet/entity/Species.java
@@ -1,0 +1,23 @@
+package com.sj.Petory.domain.pet.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Species {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "species_id")
+    private Long speciesId;
+
+    @Column(name = "species_name")
+    private String speciesName;
+}

--- a/src/main/java/com/sj/Petory/domain/pet/repository/BreedRepository.java
+++ b/src/main/java/com/sj/Petory/domain/pet/repository/BreedRepository.java
@@ -1,0 +1,15 @@
+package com.sj.Petory.domain.pet.repository;
+
+import com.sj.Petory.domain.pet.entity.Breed;
+import com.sj.Petory.domain.pet.entity.Species;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BreedRepository extends JpaRepository<Breed, Long> {
+    Breed findByBreedId(Long breedId);
+
+    List<Breed> findBySpecies(Species species);
+}

--- a/src/main/java/com/sj/Petory/domain/pet/repository/SpeciesRepository.java
+++ b/src/main/java/com/sj/Petory/domain/pet/repository/SpeciesRepository.java
@@ -1,0 +1,11 @@
+package com.sj.Petory.domain.pet.repository;
+
+import com.sj.Petory.domain.pet.entity.Species;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SpeciesRepository extends JpaRepository<Species, Long> {
+
+    Species findBySpeciesId(Long speciesId);
+}

--- a/src/main/java/com/sj/Petory/domain/pet/service/PetService.java
+++ b/src/main/java/com/sj/Petory/domain/pet/service/PetService.java
@@ -5,12 +5,18 @@ import com.sj.Petory.domain.member.dto.MemberInfoResponse;
 import com.sj.Petory.domain.member.entity.Member;
 import com.sj.Petory.domain.member.repository.MemberRepository;
 import com.sj.Petory.domain.pet.dto.PetRegister;
+import com.sj.Petory.domain.pet.entity.Breed;
 import com.sj.Petory.domain.pet.entity.Pet;
+import com.sj.Petory.domain.pet.entity.Species;
+import com.sj.Petory.domain.pet.repository.BreedRepository;
 import com.sj.Petory.domain.pet.repository.PetRepository;
+import com.sj.Petory.domain.pet.repository.SpeciesRepository;
 import com.sj.Petory.exception.MemberException;
 import com.sj.Petory.exception.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,12 +24,18 @@ public class PetService {
 
     private final MemberRepository memberRepository;
     private final PetRepository petRepository;
+    private final SpeciesRepository speciesRepository;
+    private final BreedRepository breedRepository;
+
     public boolean registerPet(
             final MemberAdapter memberAdapter,
             final PetRegister.Request request) {
         Member member = getMembers(memberAdapter);
 
-        petRepository.save(request.toEntity(member));
+        Species species = speciesRepository.findBySpeciesId(request.getSpeciesId());
+        Breed breed = breedRepository.findByBreedId(request.getBreedId());
+
+        petRepository.save(request.toEntity(member, species, breed));
 
         return true;
     }

--- a/src/main/java/com/sj/Petory/domain/pet/type/PetBreed.java
+++ b/src/main/java/com/sj/Petory/domain/pet/type/PetBreed.java
@@ -1,5 +1,0 @@
-package com.sj.Petory.domain.pet.type;
-
-public enum PetBreed {
-    치와와, 진돗개
-}

--- a/src/main/java/com/sj/Petory/domain/pet/type/PetSpecies.java
+++ b/src/main/java/com/sj/Petory/domain/pet/type/PetSpecies.java
@@ -1,5 +1,0 @@
-package com.sj.Petory.domain.pet.type;
-
-public enum PetSpecies {
-    DOG, CAT
-}

--- a/src/main/resources/db/migration/mariaDB/V10__add_column_pet_breed_id.sql
+++ b/src/main/resources/db/migration/mariaDB/V10__add_column_pet_breed_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Pet` ADD `breed_id` BIGINT NOT NULL;

--- a/src/main/resources/db/migration/mariaDB/V11__insert_data_species_and_breed.sql
+++ b/src/main/resources/db/migration/mariaDB/V11__insert_data_species_and_breed.sql
@@ -1,0 +1,10 @@
+INSERT INTO species VALUES (1, '강아지');
+INSERT INTO species VALUES (2, '고양이');
+
+INSERT INTO breed VALUES (1, 1, '치와와');
+INSERT INTO breed VALUES (2, 1, '포메라니안');
+INSERT INTO breed VALUES (3, 1, '진돗개');
+
+INSERT INTO breed VALUES (4, 2, '러시안블루');
+INSERT INTO breed VALUES (5, 2, '먼치킨');
+INSERT INTO breed VALUES (6, 2, '치즈');

--- a/src/main/resources/db/migration/mariaDB/V8__delete_column_breed_and_speices.sql
+++ b/src/main/resources/db/migration/mariaDB/V8__delete_column_breed_and_speices.sql
@@ -1,0 +1,2 @@
+ALTER TABLE Pet DROP species;
+ALTER TABLE Pet DROP breed;

--- a/src/main/resources/db/migration/mariaDB/V9__crete_table_breed_and_speices.sql
+++ b/src/main/resources/db/migration/mariaDB/V9__crete_table_breed_and_speices.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `Species` (
+	`species_id`	BIGINT	NOT NULL,
+	`species_name`	VARCHAR(50)	NOT NULL,
+	PRIMARY KEY (`species_id`)
+);
+
+CREATE TABLE `Breed` (
+	`breed_id`	BIGINT	NOT NULL,
+	`species_id`	BIGINT	NOT NULL,
+	`breed_name` VARCHAR(50)	NOT NULL,
+	PRIMARY KEY (`breed_id`, `species_id`),
+	CONSTRAINT `FK_Species_TO_Breed_1` FOREIGN KEY (`species_id`) REFERENCES `Species` (`species_id`)
+);
+
+ALTER TABLE `Pet` ADD `species_id` BIGINT NOT NULL;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
반려동물 조회 시 기존 이름, 이미지에서 세부 정보까지 함께 응답을 보내주는 것으로 수정했습니다.
반려동물을 등록할 때 species와 breed를 기존 ENUM 타입에서 테이블 형태로 분리하였습니다.
이렇게 함으로써 자주 추가될 수 있는 동물 종과 세부 종을 코드 변화 없이 데이터를 추가해주는 것으로 편리하게 할 수 있습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
