### PR TITLE
[Fix] 일정 목록 출력 API 모든 오류 해결 !

### DIFF
--- a/src/main/java/com/sj/Petory/domain/pet/repository/CareGiverRepository.java
+++ b/src/main/java/com/sj/Petory/domain/pet/repository/CareGiverRepository.java
@@ -19,6 +19,8 @@ public interface CareGiverRepository extends JpaRepository<CareGiver, Long> {
 
     Page<CareGiver> findByMember(Member member, Pageable pageable);
 
+    List<CareGiver> findByMember(Member member);
+
     boolean existsByPetAndMember(Pet pet, Member member);
 
     @Query("select cg.pet.id from CareGiver cg" +

--- a/src/main/java/com/sj/Petory/domain/pet/repository/PetRepository.java
+++ b/src/main/java/com/sj/Petory/domain/pet/repository/PetRepository.java
@@ -27,4 +27,6 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
     @Query("select p.petId from Pet p" +
             " where p.member.id = :memberId")
     List<Long> findPetIdsByMember(@Param("memberId") Long memberId);
+
+    List<Pet> findByPetId(Long petId);
 }

--- a/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
@@ -82,16 +82,9 @@ public class Schedule {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public ScheduleListResponse toDto(List<PetSchedule> petScheduleList) {
+    public ScheduleListResponse toDto(List<PetSchedule> petScheduleList
+            , List<Long> petIds, List<String> petNames) {
         Schedule scheduleEntity = this;
-
-        List<Long> petIds = petScheduleList.stream()
-                .map(petSchedule -> petSchedule.getPet().getPetId())
-                .collect(Collectors.toList());
-
-        List<String> petNames = petScheduleList.stream()
-                .map(petSchedule -> petSchedule.getPet().getPetName())
-                .collect(Collectors.toList());
 
         return ScheduleListResponse.builder()
                 .scheduleId(scheduleEntity.getScheduleId())


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
문제점
PetSchedule 엔티티에 하나의 일정에 여러 펫이 엮여있을 수 있다보니까 펫 이름이 중복되어서 나오는 경우가 있었습니다.  
자신의 펫이지만 돌보미가 일정을 생성했을 때 걸리지 않아서 해당 일정이 나타나지 않는 문제가 있었습니다.

위의 오류를 해결하기 위해 자신의 펫과 자신이 돌보미로 등록된 펫을 통해 각각 포함된 일정 아이디를 가져오고 해당 일정List들을 Set에 한 번 저장해 중복을 제거합니다.

이 중복 없는 일정 아이디로 일정 정보와 일정에 엮인펫 정보를 찾아   List<ScheduleListResponse> 형태로 반환했으나 이렇게 하니 자신과 관련없는 펫이더라도(자신의 펫도 아니고 돌보미 펫도 아닌 경우) 일정에 걸려있으면 함께 나타나는 문제가 발생했습니다. 

따라서  Dto 형태로 변환하기 전에 stream filter 를 거쳐서 자신의 펫인지, 돌보미 펫인지를 검사하고 미리 petId와 petName List로 담아놓은 후 dto 변환 메소드에 파라미터로 전달해주어 해결하였습니다. 

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
