### PR TITLE
[Feat] 일정 생성 API에 시간 관련 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,4 +80,4 @@ replay_pid*
 application.yml
 *.yml
 open-api-3.0.1.json
-src/main/resources/db/migration/h2/
+src/main/resources/db/migration/mysql/

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -44,7 +44,8 @@ dependencies {
     //restDocs
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     //openAPI3
-    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.4'// 0.16.4 -> 0.18.4
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.18.4'
+// 0.16.4 -> 0.18.4
     //swaggerUI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 

--- a/src/main/java/com/sj/Petory/domain/schedule/dto/CreateScheduleRequest.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/dto/CreateScheduleRequest.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -24,6 +25,10 @@ public class CreateScheduleRequest {
     private long categoryId;
     private String title;
     private String content;
+
+    @NotNull
+    private Boolean isAllDay;
+    private LocalTime scheduleAt;
 
     @NotNull
     private Boolean repeatYn;
@@ -44,6 +49,7 @@ public class CreateScheduleRequest {
                 .member(member)
                 .scheduleTitle(this.getTitle())
                 .scheduleContent(this.getContent())
+                .isAllDay(this.getIsAllDay())
                 .repeatYn(this.getRepeatYn())
                 .noticeYn(this.isNoticeYn())
                 .noticeAt(this.getNoticeAt())

--- a/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
@@ -16,6 +16,7 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @Entity
@@ -45,6 +46,12 @@ public class Schedule {
 
     @Column(name = "schedule_content")
     private String scheduleContent;
+
+    @Column(name = "is_all_day")
+    private boolean isAllDay;
+
+    @Column(name = "schedule_at ")
+    private LocalTime scheduleAt;
 
     @Column(name = "repeat_yn")
     private boolean repeatYn;

--- a/src/main/java/com/sj/Petory/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/service/ScheduleService.java
@@ -84,6 +84,9 @@ public class ScheduleService {
 
         Schedule schedule = scheduleRepository.save(
                 request.toScheduleEntity(member, category));
+        if (!request.getIsAllDay()) {
+            schedule.setScheduleAt(request.getScheduleAt());
+        }
 
         if (request.getRepeatYn()) {
 

--- a/src/main/resources/db/migration/mariaDB/V15__add_column_isAllDay_time.sql
+++ b/src/main/resources/db/migration/mariaDB/V15__add_column_isAllDay_time.sql
@@ -1,0 +1,3 @@
+ALTER TABLE schedule ADD is_all_day BOOLEAN NOT NULL;
+ALTER TABLE schedule ADD schedule_at TIME NULL;
+


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
로컬 테스트 DB를 mysql 로 변경하였고

일정 생성에 있어서
Schedule 테이블에 isAllDay 필드를 넣어 
true 일 경우 시간 설정 불가 (하루종일)
false 일 경우 시간 설정 (hh:mm:ss) 을 할 수 있도록 개발하였습니다. 


**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
