### PR TITLE
[Feat] 일정 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/sj/Petory/domain/pet/repository/PetRepository.java
+++ b/src/main/java/com/sj/Petory/domain/pet/repository/PetRepository.java
@@ -18,11 +18,9 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
     Page<Pet> findByMemberAndStatus(Member member, PetStatus status, Pageable pageable);
 
     Optional<Pet> findByPetIdAndMember(long petId, Member member);
-    boolean existsByPetIdAndMember(long petId, Member member);
 
     boolean existsByPetIdAndMember(Long petId, Member member);
 
-//    Page<Pet> findByMember(Member member, Pageable pageable);
 
     List<Pet> findByMember(Member member);
     @Query("select p.petId from Pet p" +

--- a/src/main/java/com/sj/Petory/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/controller/ScheduleController.java
@@ -44,15 +44,15 @@ public class ScheduleController {
                 scheduleService.createSchedule(memberAdapter, request));
     }
 
-//    @GetMapping
-//    public ResponseEntity<Page<ScheduleListResponse>> scheduleList(
-//            @AuthenticationPrincipal MemberAdapter memberAdapter
-//            , Pageable pageable) {
-//
-//        return ResponseEntity.ok(
-//                scheduleService.scheduleList(memberAdapter, pageable));
-//    }
-//
+    @GetMapping
+    public ResponseEntity<Page<ScheduleListResponse>> scheduleList(
+            @AuthenticationPrincipal MemberAdapter memberAdapter
+            , Pageable pageable) {
+
+        return ResponseEntity.ok(
+                scheduleService.scheduleList(memberAdapter, pageable));
+    }
+
 //    @GetMapping("/{scheduleId}")
 //    public ResponseEntity<ScheduleDetailResponse> scheduleDetail(
 //            @AuthenticationPrincipal MemberAdapter memberAdapter

--- a/src/main/java/com/sj/Petory/domain/schedule/dto/ScheduleListResponse.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/dto/ScheduleListResponse.java
@@ -15,11 +15,12 @@ import java.util.Set;
 @Builder
 public class ScheduleListResponse {
 
+    private Long categoryId;
     private Long scheduleId;
     private String title;
-    private LocalDateTime scheduleAt;
     private PriorityType priority;
     private ScheduleStatus status;
     private List<Long> petId;
     private List<String> petName;
+    private List<LocalDateTime> selectedDates;
 }

--- a/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.sj.Petory.domain.schedule.entity;
 
 import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.pet.entity.Pet;
 import com.sj.Petory.domain.schedule.dto.ScheduleDetailResponse;
 import com.sj.Petory.domain.schedule.dto.ScheduleListResponse;
 import com.sj.Petory.domain.schedule.dto.ScheduleUpdateRequest;
@@ -18,6 +19,7 @@ import org.springframework.util.StringUtils;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -59,6 +61,9 @@ public class Schedule {
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SelectDate> selectedDates;
 
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PetSchedule> petSchedules;
+
     @Column(name = "notice_yn")
     private boolean noticeYn;
 
@@ -84,17 +89,20 @@ public class Schedule {
     private LocalDateTime updatedAt;
 
 
-    public ScheduleListResponse toListDto(List<PetSchedule> petScheduleList
-            , List<Long> petIds, List<String> petNames) {
-        Schedule scheduleEntity = this;
+    public ScheduleListResponse toListDto(List<Pet> petList) {
 
         return ScheduleListResponse.builder()
-                .scheduleId(scheduleEntity.getScheduleId())
-                .title(scheduleEntity.getScheduleTitle())
-                .priority(scheduleEntity.getPriority())
-                .status(scheduleEntity.getStatus())
-                .petId(petIds)
-                .petName(petNames)
+                .categoryId(this.getScheduleCategory().getCategoryId())
+                .scheduleId(this.getScheduleId())
+                .title(this.getScheduleTitle())
+                .priority(this.getPriority())
+                .status(this.getStatus())
+                .petId(petList.stream().map(Pet::getPetId)
+                        .collect(Collectors.toList()))
+                .petName(petList.stream().map(Pet::getPetName)
+                        .collect(Collectors.toList()))
+                .selectedDates(this.getSelectedDates().stream()
+                        .map(SelectDate::getSelectedDate).toList())
                 .build();
     }
 

--- a/src/main/java/com/sj/Petory/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/repository/ScheduleRepository.java
@@ -17,9 +17,24 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     boolean existsByScheduleIdAndMember(Long scheduleId, Member member);
 
+    List<Schedule> findByMember(Member member);
+
     @Query("select distinct cg.member.id from CareGiver cg" +
             " join PetSchedule ps on cg.pet = ps.pet" +
             " join Schedule s on ps.schedule = s" +
             " where s.scheduleId = :scheduleId")
     List<Long> findCareGiver(@Param("scheduleId") Long scheduleId);
+
+    @Query("select s from Schedule s" +
+            " join PetSchedule ps ON s.scheduleId = ps.schedule.scheduleId" +
+            " join Pet p ON p.petId = ps.pet.petId" +
+            " join CareGiver cg ON cg.pet.petId = p.petId" +
+            " where cg.member.memberId = :memberId")
+    List<Schedule> findByAllSchedule(@Param("memberId") Long memberId);
+
+    @Query("select s from Schedule s" +
+            " join PetSchedule ps on ps.schedule.scheduleId = s.scheduleId" +
+            " join Pet p on p.petId = ps.pet.petId" +
+            " where p.member.memberId = :memberId")
+    List<Schedule> findByPetSchedule(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
일정 목록 조회 API를 구현하였습니다.
a. 자신이 만든 일정을 조회합니다. (반려동물 선택 하지 않은 항목까지 포함하기 위함)
b. 자신이 돌보미로 등록된 반려동물의 일정을 조회합니다.
c. 자신의 반려동물 리스트를 조회합니다. (자신의 반려동물이지만 돌보미가 일정을 생성했을 때 도 조회되도록 하기 위함)

a + b + c 에서 중복을 없앤 일정 리스트를 dto로 변환합니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
