### PR TITLE
[Feat] 일정 삭제 API 구현

### DIFF
--- a/src/main/java/com/sj/Petory/domain/pet/entity/Pet.java
+++ b/src/main/java/com/sj/Petory/domain/pet/entity/Pet.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -18,6 +19,7 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Builder
@@ -35,6 +37,10 @@ public class Pet {
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
+    private List<CareGiver> careGivers;
 
     @Column
     private String petName;

--- a/src/main/java/com/sj/Petory/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/controller/ScheduleController.java
@@ -5,7 +5,6 @@ import com.sj.Petory.domain.schedule.dto.*;
 import com.sj.Petory.domain.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;

--- a/src/main/java/com/sj/Petory/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/controller/ScheduleController.java
@@ -87,4 +87,15 @@ public class ScheduleController {
                 scheduleService.scheduleStatus(
                         memberAdapter, scheduleId, request));
     }
-}
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Boolean> deleteSchedule(
+            @AuthenticationPrincipal MemberAdapter memberAdapter
+            , @PathVariable("scheduleId") Long scheduleId
+            , @RequestParam("scheduleAt") @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime scheduleAt) {
+
+
+            return ResponseEntity.ok(
+                    scheduleService.deleteSchedule(memberAdapter, scheduleId, scheduleAt));
+        }
+    }

--- a/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
@@ -5,6 +5,7 @@ import com.sj.Petory.domain.pet.entity.Pet;
 import com.sj.Petory.domain.schedule.dto.ScheduleDetailResponse;
 import com.sj.Petory.domain.schedule.dto.ScheduleListResponse;
 import com.sj.Petory.domain.schedule.type.PriorityType;
+import com.sj.Petory.domain.schedule.type.ScheduleStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.BatchSize;
@@ -96,6 +97,7 @@ public class Schedule {
                 .petName(petList.stream().map(Pet::getPetName)
                         .collect(Collectors.toList()))
                 .dateInfo(this.getSelectedDates().stream()
+                        .filter(date -> !date.getStatus().equals(ScheduleStatus.DELETED))
                         .map(SelectDate::toDateInfo).toList())
                 .build();
     }

--- a/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/entity/Schedule.java
@@ -7,6 +7,7 @@ import com.sj.Petory.domain.schedule.dto.ScheduleListResponse;
 import com.sj.Petory.domain.schedule.type.PriorityType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -55,9 +56,11 @@ public class Schedule {
     private boolean repeatYn;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private List<SelectDate> selectedDates;
 
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private List<PetSchedule> petSchedules;
 
     @Column(name = "notice_yn")

--- a/src/main/java/com/sj/Petory/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/repository/ScheduleRepository.java
@@ -17,6 +17,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     boolean existsByScheduleIdAndMember(Long scheduleId, Member member);
 
+    Optional<Schedule> findByScheduleIdAndMember(Long scheduleId, Member member);
+
     List<Schedule> findByMember(Member member);
 
     @Query("select distinct cg.member.id from CareGiver cg" +

--- a/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
+++ b/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     INVALID_REPEAT_PATTERN("유효하지 않은 반복 패턴입니다.", HttpStatus.BAD_REQUEST),
     MISSING_START_OR_END_DATE("시작/종료 일자는 필수 항목입니다.", HttpStatus.BAD_REQUEST),
     DATE_NOT_FOUND("날짜를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SCHEDULE_ACCESS("일정 접근 권한이 없습니다.", HttpStatus.BAD_REQUEST),
     //s3
     FILE_EMPTY("유효하지 않은 파일입니다.", HttpStatus.BAD_REQUEST),
     FILE_EXTENSION_NOT_ALLOWED("이미지 파일만 업로드 가능합니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
일정 삭제 api를 구현했습니다.
일정을 만든 사용자와 해당 일정에 묶인 펫의 돌보미이면 삭제 가능합니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
