### PR TITLE
[Fix] 구독 요청 api 쿼리파람으로 토큰 받도록 변경

### DIFF
--- a/src/main/java/com/sj/Petory/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/sj/Petory/domain/notification/controller/NotificationController.java
@@ -21,9 +21,9 @@ public class NotificationController {
 
     @GetMapping("/subscribe")
     public SseEmitter subscribe(
-            @AuthenticationPrincipal MemberAdapter memberAdapter) {
+            @RequestParam("token") String token) {
 
-        return notificationService.subscribe(memberAdapter);
+        return notificationService.subscribe(token);
     }
 
     @GetMapping

--- a/src/main/java/com/sj/Petory/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/sj/Petory/domain/notification/service/NotificationService.java
@@ -10,10 +10,12 @@ import com.sj.Petory.domain.notification.repository.NotificationRepository;
 import com.sj.Petory.domain.notification.type.NoticeType;
 import com.sj.Petory.exception.MemberException;
 import com.sj.Petory.exception.type.ErrorCode;
+import com.sj.Petory.security.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -31,12 +33,16 @@ public class NotificationService {
 
     private final Map<Long, SseEmitter> emitterMap = new HashMap<>();
 
+    private final JwtUtils jwtUtils;
+
     //SSE 구독 (클라이언트가 알림을 수신하기 위해 호출)
     public SseEmitter subscribe(
-            final MemberAdapter memberAdapter) {
+            final String token) {
+
+        Authentication authentication = jwtUtils.getAuthentication(token);
+        MemberAdapter memberAdapter = (MemberAdapter) authentication.getPrincipal();
 
         Member member = getMemberByEmail(memberAdapter.getEmail());
-
 
         SseEmitter emitter = new SseEmitter(3_600_000L);
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
프론트에서 EventSource로 SseEmitter 연결 요청을 보내는데 여기엔 헤더를 보낼 수 없어서 토큰을 쿼리 파람으로 보내 파싱해서 사용자를 찾는 방식으로 변경하였습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
