### PR TITLE
[Fix] DB 커넥션 풀 오류 해결

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/dto/MemberAdapter.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/MemberAdapter.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 @Builder
 public class MemberAdapter implements UserDetails{
 
+    private final Long memberId;
     private final String email;
     private final String password;
 

--- a/src/main/java/com/sj/Petory/domain/member/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/UserDetailsServiceImpl.java
@@ -24,6 +24,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
 
 
-        return new MemberAdapter(member.getEmail(), member.getPassword());
+        return new MemberAdapter(
+                member.getMemberId(), member.getEmail(), member.getPassword());
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
/subscribe 하는 과정에서 member를 DB에서 계속 조회해오고 있어 몇 번의 새로고침을 거치면 DB 커넥션 풀 오류가 발생.
-> /subscribe에서는 token을 파싱해 memberAdapter를 가져오고 memberAdapter에서 이메일을 가져와 DB에서 Member를 조회해 memberId를 가져왔음. 이 과정을 memberAdpater의 필드로 memberId를 추가해 DB 조회를 거치지 않도록 함. 

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
