### PR TITLE
[Fix] 일정에 관련된 모든 사용자에게 알림 발송하도록 로직 수정

### DIFF
--- a/src/main/java/com/sj/Petory/domain/notification/repository/ScheduleNotificationRepository.java
+++ b/src/main/java/com/sj/Petory/domain/notification/repository/ScheduleNotificationRepository.java
@@ -21,5 +21,4 @@ public interface ScheduleNotificationRepository extends JpaRepository<ScheduleNo
         WHERE snt.notice_time = :targetTime
         """, nativeQuery = true)
     List<ScheduleNotification> findByNoticeTime(@Param("targetTime") LocalDateTime targetTime);
-    // 이렇게 List 조회 불가 NativeQUery 써야함
 }

--- a/src/main/java/com/sj/Petory/domain/pet/repository/PetRepository.java
+++ b/src/main/java/com/sj/Petory/domain/pet/repository/PetRepository.java
@@ -28,4 +28,9 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
     List<Long> findPetIdsByMember(@Param("memberId") Long memberId);
 
     Optional<Pet> findByPetId(Long petId);
+
+    @Query("select p.member.memberId" +
+            " from Pet p" +
+            " where p.petId in :petIds")
+    List<Long> findMemberIdsByPet(@Param("petIds")List<Long> petIds);
 }

--- a/src/main/java/com/sj/Petory/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/sj/Petory/domain/schedule/repository/ScheduleRepository.java
@@ -17,8 +17,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     boolean existsByScheduleIdAndMember(Long scheduleId, Member member);
 
-    Optional<Schedule> findByScheduleIdAndMember(Long scheduleId, Member member);
-
     List<Schedule> findByMember(Member member);
 
     @Query("select distinct cg.member.id from CareGiver cg" +


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
기존 일정 생성자 + 일정에 포함된 펫의 돌보미들을 List에 담아서 알림을 전송했는데 이 경우에 자신의 반려동물인데 돌보미가 일정을 생성했을 경우에 알림이 누락되는 현상이 발생 ->
1. 일정 생성자 (펫 없는 일정에서도 가져오기 위함)
2. 일정에 있는 펫의 주인(돌보미가 내 펫 가지고 일정 만들었을 떄도 커버가능)
3. 일정에 있는 펫의 돌보미 
이렇게 3 경우로 나눠서 Member를 가져오고 중복을 제거하여 일정에 관련된 사용자라면 빠짐없이 알림을 수신할 수 있도록 하였습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
