### PR TITLE
[Feat] 안 읽은 알림 count 실시간 전송 구현

### DIFF
--- a/src/main/java/com/sj/Petory/domain/notification/dto/NotificationPayloadDto.java
+++ b/src/main/java/com/sj/Petory/domain/notification/dto/NotificationPayloadDto.java
@@ -1,6 +1,5 @@
 package com.sj.Petory.domain.notification.dto;
 
-import com.sj.Petory.domain.member.entity.Member;
 import com.sj.Petory.domain.notification.type.NoticeType;
 import lombok.*;
 
@@ -16,4 +15,5 @@ public class NotificationPayloadDto {
     private Long entityId;
     private Long sendMemberId;
     private String sendMemberName;
+    private Long unReadCount;
 }

--- a/src/main/java/com/sj/Petory/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sj/Petory/domain/notification/repository/NotificationRepository.java
@@ -16,4 +16,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Page<Notification> findByMember(Member member, Pageable pageable);
 
     Optional<Notification> findByNoticeIdAndMember(Long noticeId, Member member);
+
+    long countByMemberAndIsRead(Member member, boolean b);
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
새로운 알림을 보낼 때 noticePayloadDto에 unReadCount를 추가하여 안 읽은 알림 개수를 프론트에서 확인 할 수 있게 함.
알림 읽음 처리 후에 안 읽은 알림 갯수를 unReadCount로 실시간 전송

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
