### PR TITLE
[Fix] ES와 회원 DB 동기화시켜 정합성 유지

### DIFF
--- a/src/main/java/com/sj/Petory/common/es/MemberDocument.java
+++ b/src/main/java/com/sj/Petory/common/es/MemberDocument.java
@@ -1,16 +1,14 @@
 package com.sj.Petory.common.es;
 
 import com.sj.Petory.domain.friend.dto.MemberSearchResponse;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -24,4 +22,13 @@ public class MemberDocument {
 
     private String name;
     private String email;
+
+    public MemberDocument updateName(String newName) {
+
+        return MemberDocument.builder()
+                .memberId(this.getMemberId())
+                .name(newName)
+                .email(this.getEmail())
+                .build();
+    }
 }

--- a/src/main/java/com/sj/Petory/common/es/MemberDocument.java
+++ b/src/main/java/com/sj/Petory/common/es/MemberDocument.java
@@ -24,13 +24,4 @@ public class MemberDocument {
 
     private String name;
     private String email;
-    private String image;
-
-    public MemberSearchResponse toDto() {
-        return MemberSearchResponse.builder()
-                .id(this.memberId)
-                .name(this.getName())
-                .image(this.getImage())
-                .build();
-    }
 }

--- a/src/main/java/com/sj/Petory/domain/friend/service/FriendService.java
+++ b/src/main/java/com/sj/Petory/domain/friend/service/FriendService.java
@@ -23,16 +23,19 @@ import com.sj.Petory.exception.FriendException;
 import com.sj.Petory.exception.MemberException;
 import com.sj.Petory.exception.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FriendService {
 
     private final FriendRepository friendRepository;
@@ -47,8 +50,12 @@ public class FriendService {
     public Page<MemberSearchResponse> searchMember(
             final String keyword, final Pageable pageable) {
 
+
         return memberEsRepository.findByNameOrEmail(keyword, keyword, pageable)
-                .map(MemberDocument::toDto);
+                .map(doc -> {
+                    return memberRepository.findById(doc.getMemberId())
+                            .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+                }).map(Member::toDto);
     }
 
     public Boolean friendRequest(

--- a/src/main/java/com/sj/Petory/domain/member/dto/SignUp.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/SignUp.java
@@ -45,7 +45,6 @@ public class SignUp {
                     .memberId(member.getMemberId())
                     .name(member.getName())
                     .email(member.getEmail())
-                    .image(member.getImage())
                     .build();
         }
     }

--- a/src/main/java/com/sj/Petory/domain/member/entity/Member.java
+++ b/src/main/java/com/sj/Petory/domain/member/entity/Member.java
@@ -57,6 +57,14 @@ public class Member {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    public MemberSearchResponse toDto() {
+        return MemberSearchResponse.builder()
+                .id(this.memberId)
+                .name(this.getName())
+                .image(this.getImage())
+                .build();
+    }
+
     public Member updateInfo(final UpdateMemberRequest request) {
         if (StringUtils.hasText(request.getName())) {
             this.name = request.getName();

--- a/src/main/java/com/sj/Petory/domain/member/event/MemberDeletedEvent.java
+++ b/src/main/java/com/sj/Petory/domain/member/event/MemberDeletedEvent.java
@@ -1,8 +1,10 @@
 package com.sj.Petory.domain.member.event;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public class MemberDeletedEvent {
 
     private final Long memberId;

--- a/src/main/java/com/sj/Petory/domain/member/event/MemberDeletedEvent.java
+++ b/src/main/java/com/sj/Petory/domain/member/event/MemberDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.sj.Petory.domain.member.event;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberDeletedEvent {
+
+    private final Long memberId;
+}

--- a/src/main/java/com/sj/Petory/domain/member/event/MemberEventListener.java
+++ b/src/main/java/com/sj/Petory/domain/member/event/MemberEventListener.java
@@ -1,0 +1,36 @@
+package com.sj.Petory.domain.member.event;
+
+import com.sj.Petory.common.es.MemberDocument;
+import com.sj.Petory.common.es.MemberEsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class MemberEventListener {
+
+    private final MemberEsRepository memberEsRepository;
+
+    @EventListener
+    public void handleMemberUpdateEvent(MemberUpdatedEvent event) {
+        log.info("MemberEventListener handleMemberUpdateEvent");
+        log.info(event.getName());
+        memberEsRepository.findById(event.getMemberId())
+                .ifPresent(doc -> {
+                    MemberDocument updatedDoc = doc.updateName(event.getName());
+                    memberEsRepository.save(updatedDoc);
+                });
+    }
+
+    @EventListener
+    public void handleMemberDeletedEvent(MemberDeletedEvent event) {
+
+        memberEsRepository.deleteById(event.getMemberId());
+    }
+}

--- a/src/main/java/com/sj/Petory/domain/member/event/MemberUpdatedEvent.java
+++ b/src/main/java/com/sj/Petory/domain/member/event/MemberUpdatedEvent.java
@@ -1,0 +1,10 @@
+package com.sj.Petory.domain.member.event;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberUpdatedEvent {
+
+    private final Long memberId;
+    private final String name;
+}

--- a/src/main/java/com/sj/Petory/domain/member/event/MemberUpdatedEvent.java
+++ b/src/main/java/com/sj/Petory/domain/member/event/MemberUpdatedEvent.java
@@ -1,8 +1,10 @@
 package com.sj.Petory.domain.member.event;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public class MemberUpdatedEvent {
 
     private final Long memberId;

--- a/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
@@ -30,7 +30,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PetRepository petRepository;
     private final PostRepository postRepository;
-    private final SpeciesRepository speciesRepository;
     private final BreedRepository breedRepository;
 
     private final MemberEsRepository memberEsRepository;

--- a/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
@@ -4,11 +4,12 @@ import com.sj.Petory.common.es.MemberEsRepository;
 import com.sj.Petory.common.s3.AmazonS3Service;
 import com.sj.Petory.domain.member.dto.*;
 import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.member.event.MemberDeletedEvent;
+import com.sj.Petory.domain.member.event.MemberUpdatedEvent;
 import com.sj.Petory.domain.member.repository.MemberRepository;
 import com.sj.Petory.domain.member.type.MemberStatus;
 import com.sj.Petory.domain.pet.repository.BreedRepository;
 import com.sj.Petory.domain.pet.repository.PetRepository;
-import com.sj.Petory.domain.pet.repository.SpeciesRepository;
 import com.sj.Petory.domain.pet.type.PetStatus;
 import com.sj.Petory.domain.post.entity.Post;
 import com.sj.Petory.domain.post.repository.PostRepository;
@@ -16,6 +17,7 @@ import com.sj.Petory.exception.MemberException;
 import com.sj.Petory.exception.type.ErrorCode;
 import com.sj.Petory.security.JwtUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -38,6 +40,7 @@ public class MemberService {
 
     private final JwtUtils jwtUtils;
     private final AmazonS3Service amazonS3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     public boolean signUp(final SignUp.Request request) {
 
@@ -121,7 +124,13 @@ public class MemberService {
     public boolean updateMember(final MemberAdapter memberAdapter, final UpdateMemberRequest request) {
         Member member = getMemberByEmail(memberAdapter.getEmail());
 
-        checkNameDuplicate(request.getName());
+        String name = request.getName();
+        if (name != null) {
+            checkNameDuplicate(name);
+
+            eventPublisher.publishEvent(
+                    new MemberUpdatedEvent(member.getMemberId(), name));
+        }
 
         if (StringUtils.hasText(request.getPassword())) {
             request.setPassword(
@@ -137,6 +146,8 @@ public class MemberService {
         Member member = getMemberByEmail(memberAdapter.getEmail());
 
         validateDeleteMember(member);
+
+        eventPublisher.publishEvent(new MemberDeletedEvent(member.getMemberId()));
 
         member.updateStatus(MemberStatus.DELETED);
 

--- a/src/main/resources/elastic/member-mappings.json
+++ b/src/main/resources/elastic/member-mappings.json
@@ -10,9 +10,6 @@
     "email": {
       "type": "text",
       "analyzer": "member_search_analyzer"
-    },
-    "image": {
-      "type": "text"
     }
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- MemberDocument에 기존에 image 필드가 있던 부분을 제거해서 검색에 필요한 필드만 저장하도록 수정

- 회원 검색의 결과 값으로 기존 document -> dto로 변환해 내려주던 것을 document로 찾아온 회원 id를 Member DB 에서 Id로 조회 후 받아온 Member를 dto로 변환해서 반환하는 로직으로 수정
    => 검색은 ES에서, 최신 정보를 받아오는 것은 DB에서 역할 분리를 함으로써 효율적인 데이터 조회와 관리가 가능하도록 함.

- EventListener를 통해 이름 변경, 회원 삭제 시 ES에도 동일하게 반영되도록 MemberEventListener 생성

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
