### PR TITLE
[Feat] 게시글 업로드 구현에 필요한 여러 이미지 받는 로직 구현

### DIFF
--- a/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
+++ b/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
@@ -6,10 +6,7 @@ import com.sj.Petory.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,10 +15,10 @@ public class PostController {
 
     private final PostService postService;
 
-    @PostMapping("/posts")
+    @PostMapping(value = "/posts", consumes = "multipart/form-data")
     public ResponseEntity<Boolean> createPost(
             @AuthenticationPrincipal MemberAdapter memberAdapter,
-            @RequestBody CreatePostRequest createPostRequest) {
+            @ModelAttribute CreatePostRequest createPostRequest) {
 
         return ResponseEntity.ok(postService.createPost(memberAdapter, createPostRequest));
     }

--- a/src/main/java/com/sj/Petory/domain/post/dto/CreatePostRequest.java
+++ b/src/main/java/com/sj/Petory/domain/post/dto/CreatePostRequest.java
@@ -1,6 +1,9 @@
 package com.sj.Petory.domain.post.dto;
 
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,5 +15,5 @@ public class CreatePostRequest {
     private Long categoryId;
     private String title;
     private String content;
-    private String imageUrl;
+    private List<MultipartFile> image;
 }

--- a/src/main/java/com/sj/Petory/domain/post/service/PostService.java
+++ b/src/main/java/com/sj/Petory/domain/post/service/PostService.java
@@ -3,12 +3,18 @@ package com.sj.Petory.domain.post.service;
 import com.sj.Petory.domain.member.dto.MemberAdapter;
 import com.sj.Petory.domain.post.dto.CreatePostRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class PostService {
-    public Boolean createPost(MemberAdapter memberAdapter, CreatePostRequest createPostRequest) {
+    public Boolean createPost(
+            final MemberAdapter memberAdapter
+            , final CreatePostRequest createPostRequest) {
+        log.info(createPostRequest.getImage().toString());
 
         return true;
     }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
게시글 create API 구현에 앞서 이미지를 여러 장 업로드할 수 있는 작업을 했습니다.
@ModelAttribute를 이용해 form-data 형식으로 게시글 생성에 필요한 제목, 내용, 카테고리 아이디를 key-value 형태로 받아오고 이미지 또한 동시에 업로드 할 수 있게 했습니다.

**TO-BE**
컨트롤러에서 받은 이미지 파일 S3에 업로드

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
