### PR TITLE
[Feat] 게시글 피드 목록 조회 API 구현 

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/dto/PostMemberInfo.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/PostMemberInfo.java
@@ -1,0 +1,15 @@
+package com.sj.Petory.domain.member.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PostMemberInfo {
+
+    private long id;
+    private String image;
+    private String name;
+}

--- a/src/main/java/com/sj/Petory/domain/member/dto/PostResponse.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/PostResponse.java
@@ -2,6 +2,8 @@ package com.sj.Petory.domain.member.dto;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -11,4 +13,5 @@ public class PostResponse {
     private long postId;
     private String title;
     private String content;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/sj/Petory/domain/member/entity/Member.java
+++ b/src/main/java/com/sj/Petory/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.sj.Petory.domain.member.entity;
 
 import com.sj.Petory.common.es.MemberDocument;
 import com.sj.Petory.domain.friend.dto.MemberSearchResponse;
+import com.sj.Petory.domain.member.dto.PostMemberInfo;
 import com.sj.Petory.domain.member.dto.UpdateMemberRequest;
 import com.sj.Petory.domain.member.type.MemberStatus;
 import jakarta.persistence.*;
@@ -95,5 +96,14 @@ public class Member {
 
     public void updateImage(final String imageUrl) {
         this.image = imageUrl;
+    }
+
+    public PostMemberInfo toPostMemberDto() {
+
+        return PostMemberInfo.builder()
+                .id(this.getMemberId())
+                .image(this.getImage())
+                .name(this.getName())
+                .build();
     }
 }

--- a/src/main/java/com/sj/Petory/domain/pet/entity/Breed.java
+++ b/src/main/java/com/sj/Petory/domain/pet/entity/Breed.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "breed")
 public class Breed {
 
     @Id

--- a/src/main/java/com/sj/Petory/domain/post/comment/Comment.java
+++ b/src/main/java/com/sj/Petory/domain/post/comment/Comment.java
@@ -1,0 +1,26 @@
+package com.sj.Petory.domain.post.comment;
+
+import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.post.entity.Post;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "comment")
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private long commentId;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "content")
+    private String content;
+}

--- a/src/main/java/com/sj/Petory/domain/post/comment/CommentController.java
+++ b/src/main/java/com/sj/Petory/domain/post/comment/CommentController.java
@@ -1,0 +1,4 @@
+package com.sj.Petory.domain.post.comment;
+
+public class CommentController {
+}

--- a/src/main/java/com/sj/Petory/domain/post/comment/CommentRepository.java
+++ b/src/main/java/com/sj/Petory/domain/post/comment/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.sj.Petory.domain.post.comment;
+
+import com.sj.Petory.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    long countAllByPost(Post post);
+}

--- a/src/main/java/com/sj/Petory/domain/post/controller/PostCategoryController.java
+++ b/src/main/java/com/sj/Petory/domain/post/controller/PostCategoryController.java
@@ -1,0 +1,25 @@
+package com.sj.Petory.domain.post.controller;
+
+import com.sj.Petory.domain.post.dto.PostCategoryResponse;
+import com.sj.Petory.domain.post.service.PostCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/community/category")
+public class PostCategoryController {
+
+    private final PostCategoryService postCategoryService;
+
+    @GetMapping
+    public ResponseEntity<List<PostCategoryResponse>> getCategory() {
+
+        return ResponseEntity.ok(postCategoryService.getCategory());
+    }
+}

--- a/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
+++ b/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import com.sj.Petory.domain.member.dto.MemberAdapter;
 import com.sj.Petory.domain.post.dto.CreatePostRequest;
 import com.sj.Petory.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -15,7 +16,7 @@ public class PostController {
 
     private final PostService postService;
 
-    @PostMapping(value = "/posts", consumes = "multipart/form-data")
+    @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Boolean> createPost(
             @AuthenticationPrincipal MemberAdapter memberAdapter,
             @ModelAttribute CreatePostRequest createPostRequest) {

--- a/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
+++ b/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.sj.Petory.domain.post.controller;
 
 import com.sj.Petory.domain.member.dto.MemberAdapter;
+import com.sj.Petory.domain.post.dto.AllPostResponse;
 import com.sj.Petory.domain.post.dto.CreatePostRequest;
 import com.sj.Petory.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
@@ -9,18 +10,27 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/community")
+@RequestMapping("/community/posts")
 public class PostController {
 
     private final PostService postService;
 
-    @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Boolean> createPost(
             @AuthenticationPrincipal MemberAdapter memberAdapter,
             @ModelAttribute CreatePostRequest createPostRequest) {
 
         return ResponseEntity.ok(postService.createPost(memberAdapter, createPostRequest));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AllPostResponse>> getPostList(
+            @AuthenticationPrincipal MemberAdapter memberAdapter) {
+
+        return ResponseEntity.ok(postService.getPostList());
     }
 }

--- a/src/main/java/com/sj/Petory/domain/post/dto/AllPostResponse.java
+++ b/src/main/java/com/sj/Petory/domain/post/dto/AllPostResponse.java
@@ -1,0 +1,27 @@
+package com.sj.Petory.domain.post.dto;
+
+
+import com.sj.Petory.domain.member.dto.PostMemberInfo;
+import com.sj.Petory.domain.member.dto.PostResponse;
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+public class AllPostResponse {
+
+    //게시글 작성자 정보
+    private PostMemberInfo member;
+
+    //게시글 정보
+    private PostResponse post;
+
+    private List<PostImageDto> postImageList;
+
+    //댓글 수
+    //공감 수
+}

--- a/src/main/java/com/sj/Petory/domain/post/dto/AllPostResponse.java
+++ b/src/main/java/com/sj/Petory/domain/post/dto/AllPostResponse.java
@@ -23,5 +23,7 @@ public class AllPostResponse {
     private List<PostImageDto> postImageList;
 
     //댓글 수
+    private long commentTotal;
     //공감 수
+    private long sympathyTotal;
 }

--- a/src/main/java/com/sj/Petory/domain/post/dto/PostCategoryResponse.java
+++ b/src/main/java/com/sj/Petory/domain/post/dto/PostCategoryResponse.java
@@ -1,0 +1,11 @@
+package com.sj.Petory.domain.post.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class PostCategoryResponse {
+
+    private long categoryId;
+    private String categoryName;
+}

--- a/src/main/java/com/sj/Petory/domain/post/dto/PostInfo.java
+++ b/src/main/java/com/sj/Petory/domain/post/dto/PostInfo.java
@@ -1,0 +1,15 @@
+package com.sj.Petory.domain.post.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostInfo {
+
+    private long postId;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/sj/Petory/domain/post/entity/Post.java
+++ b/src/main/java/com/sj/Petory/domain/post/entity/Post.java
@@ -63,6 +63,7 @@ public class Post {
                 .postId(this.postId)
                 .title(this.postTitle)
                 .content(this.postContent)
+                .createdAt(this.createdAt)
                 .build();
     }
 }

--- a/src/main/java/com/sj/Petory/domain/post/entity/PostCategory.java
+++ b/src/main/java/com/sj/Petory/domain/post/entity/PostCategory.java
@@ -1,7 +1,6 @@
 package com.sj.Petory.domain.post.entity;
 
-import com.sj.Petory.domain.member.entity.Member;
-import com.sj.Petory.domain.post.entity.Post;
+import com.sj.Petory.domain.post.dto.PostCategoryResponse;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,7 +10,6 @@ import java.util.List;
 @Entity
 @Builder
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
@@ -26,4 +24,10 @@ public class PostCategory {
     private List<Post> postList;
 
     private String categoryName;
+
+    public PostCategoryResponse toDto() {
+        return new PostCategoryResponse(
+                this.getPostCategoryId(),
+                this.getCategoryName());
+    }
 }

--- a/src/main/java/com/sj/Petory/domain/post/entity/PostImage.java
+++ b/src/main/java/com/sj/Petory/domain/post/entity/PostImage.java
@@ -1,5 +1,6 @@
 package com.sj.Petory.domain.post.entity;
 
+import com.sj.Petory.domain.post.dto.PostImageDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,4 +23,9 @@ public class PostImage {
 
     @Column(name = "image_url")
     private String imageUrl;
+
+    public PostImageDto toDto() {
+
+        return new PostImageDto(imageUrl);
+    }
 }

--- a/src/main/java/com/sj/Petory/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/sj/Petory/domain/post/repository/PostImageRepository.java
@@ -1,0 +1,14 @@
+package com.sj.Petory.domain.post.repository;
+
+import com.sj.Petory.domain.post.entity.Post;
+import com.sj.Petory.domain.post.entity.PostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+    List<PostImage> findByPostId(Post postId);
+}

--- a/src/main/java/com/sj/Petory/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sj/Petory/domain/post/repository/PostRepository.java
@@ -2,13 +2,20 @@ package com.sj.Petory.domain.post.repository;
 
 import com.sj.Petory.domain.member.entity.Member;
 import com.sj.Petory.domain.post.entity.Post;
+import com.sj.Petory.domain.post.type.PostStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByMember(Member member, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "postImageList"})
+    List<Post> findByStatus(PostStatus postStatus);
 }

--- a/src/main/java/com/sj/Petory/domain/post/service/PostCategoryService.java
+++ b/src/main/java/com/sj/Petory/domain/post/service/PostCategoryService.java
@@ -1,0 +1,25 @@
+package com.sj.Petory.domain.post.service;
+
+import com.sj.Petory.domain.post.dto.PostCategoryResponse;
+import com.sj.Petory.domain.post.entity.PostCategory;
+import com.sj.Petory.domain.post.repository.PostCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostCategoryService {
+
+    private final PostCategoryRepository postCategoryRepository;
+
+
+    public List<PostCategoryResponse> getCategory() {
+
+        return postCategoryRepository.findAll().stream()
+                .map(PostCategory::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/sj/Petory/domain/post/service/PostService.java
+++ b/src/main/java/com/sj/Petory/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.sj.Petory.common.s3.AmazonS3Service;
 import com.sj.Petory.domain.member.dto.MemberAdapter;
 import com.sj.Petory.domain.member.entity.Member;
 import com.sj.Petory.domain.member.repository.MemberRepository;
+import com.sj.Petory.domain.post.comment.CommentRepository;
 import com.sj.Petory.domain.post.dto.AllPostResponse;
 import com.sj.Petory.domain.post.dto.CreatePostRequest;
 import com.sj.Petory.domain.post.dto.PostImageDto;
@@ -13,6 +14,7 @@ import com.sj.Petory.domain.post.entity.PostImage;
 import com.sj.Petory.domain.post.repository.PostCategoryRepository;
 import com.sj.Petory.domain.post.repository.PostImageRepository;
 import com.sj.Petory.domain.post.repository.PostRepository;
+import com.sj.Petory.domain.post.sympathy.SympathyRepository;
 import com.sj.Petory.domain.post.type.PostStatus;
 import com.sj.Petory.exception.MemberException;
 import com.sj.Petory.exception.PostException;
@@ -35,6 +37,8 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
     private final AmazonS3Service s3Service;
+    private final CommentRepository commentRepository;
+    private final SympathyRepository sympathyRepository;
 
     @Transactional
     public Boolean createPost(
@@ -80,8 +84,11 @@ public class PostService {
                         .member(post.getMember().toPostMemberDto())
                         .post(post.toDto())
                         .postImageList(
-                                post.getPostImageList().stream().map(PostImage::toDto)
+                                post.getPostImageList().stream()
+                                        .map(PostImage::toDto)
                                         .toList())
+                        .commentTotal(commentRepository.countAllByPost(post))
+                        .sympathyTotal(sympathyRepository.countAllByPost(post))
                         .build()
                 ).collect(Collectors.toList());
     }

--- a/src/main/java/com/sj/Petory/domain/post/sympathy/Sympathy.java
+++ b/src/main/java/com/sj/Petory/domain/post/sympathy/Sympathy.java
@@ -1,0 +1,27 @@
+package com.sj.Petory.domain.post.sympathy;
+
+import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.post.entity.Post;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "sympathy")
+public class Sympathy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "sympathy_id")
+    private long sympathyId;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private SympathyType type;
+}

--- a/src/main/java/com/sj/Petory/domain/post/sympathy/SympathyRepository.java
+++ b/src/main/java/com/sj/Petory/domain/post/sympathy/SympathyRepository.java
@@ -1,0 +1,12 @@
+package com.sj.Petory.domain.post.sympathy;
+
+import com.sj.Petory.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SympathyRepository extends JpaRepository<Sympathy, Long> {
+
+    long countAllByPost(Post post);
+
+}

--- a/src/main/java/com/sj/Petory/domain/post/sympathy/SympathyType.java
+++ b/src/main/java/com/sj/Petory/domain/post/sympathy/SympathyType.java
@@ -1,0 +1,15 @@
+package com.sj.Petory.domain.post.sympathy;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SympathyType {
+    LIKE("좋아요", "☺️"),
+    AWESOME("멋져요", "😎"),
+    FUNNY("웃겨요", "😂"),
+    SAD("슬퍼요", "😢"),
+    USEFUL("유용해요", "📌");
+
+    private final String displayName;
+    private final String emoji;
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
게시글 피드 목록 조회 API 구현했습니다.
인스타그램 피드같이 최신순으로 조회될 예정이며 댓글 수와 공감수도 함께 노출됩니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
