### PR TITLE
[Feat] 게시글 피드 조회 API 응답에 카테고리 정보 추가

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/dto/PostResponse.java
+++ b/src/main/java/com/sj/Petory/domain/member/dto/PostResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class PostResponse {
+    private long categoryId;
     private long postId;
     private String title;
     private String content;

--- a/src/main/java/com/sj/Petory/domain/post/entity/Post.java
+++ b/src/main/java/com/sj/Petory/domain/post/entity/Post.java
@@ -63,10 +63,11 @@ public class Post {
 
     public PostResponse toDto() {
         return PostResponse.builder()
-                .postId(this.postId)
-                .title(this.postTitle)
-                .content(this.postContent)
-                .createdAt(this.createdAt)
+                .categoryId(this.getPostCategory().getPostCategoryId())
+                .postId(this.getPostId())
+                .title(this.getPostTitle())
+                .content(this.getPostContent())
+                .createdAt(this.getCreatedAt())
                 .build();
     }
     public void clearPostImages() {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
프론트의 요청에 따라 게시글 피드 목록 조회 API 응답에 게시글 카테고리 정보를 추가하였습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
