### PR TITLE
[Refactor] 회원삭제, 게시글 삭제에 따른 DB, ES 정합성 작업 및 이벤트 발행 로직 개선

### DIFF
--- a/src/main/java/com/sj/Petory/domain/member/entity/Member.java
+++ b/src/main/java/com/sj/Petory/domain/member/entity/Member.java
@@ -5,6 +5,8 @@ import com.sj.Petory.domain.friend.dto.MemberSearchResponse;
 import com.sj.Petory.domain.member.dto.PostMemberInfo;
 import com.sj.Petory.domain.member.dto.UpdateMemberRequest;
 import com.sj.Petory.domain.member.type.MemberStatus;
+import com.sj.Petory.domain.post.comment.Comment;
+import com.sj.Petory.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +19,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -51,6 +55,12 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
+    @OneToMany(mappedBy = "member")
+    private List<Post> posts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Comment> comments = new ArrayList<>();
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -82,8 +92,13 @@ public class Member {
         }
     }
 
-    public void updateStatus(final MemberStatus memberStatus) {
-        this.status = memberStatus;
+    public void softDelete() {
+
+        this.status = MemberStatus.DELETED;
+
+        posts.forEach(Post::softDelete);
+        comments.forEach(Comment::softDelete);
+
     }
 
     public void updateImage(final String imageUrl) {

--- a/src/main/java/com/sj/Petory/domain/member/event/MemberEventListener.java
+++ b/src/main/java/com/sj/Petory/domain/member/event/MemberEventListener.java
@@ -1,14 +1,27 @@
 package com.sj.Petory.domain.member.event;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
 import com.sj.Petory.common.es.MemberDocument;
 import com.sj.Petory.common.es.MemberEsRepository;
+import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.member.repository.MemberRepository;
+import com.sj.Petory.domain.member.type.MemberStatus;
+import com.sj.Petory.domain.post.comment.CommentRepository;
+import com.sj.Petory.domain.post.repository.PostEsRepository;
+import com.sj.Petory.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -16,10 +29,41 @@ import java.util.Optional;
 @Slf4j
 public class MemberEventListener {
 
+    private final MemberRepository memberRepository;
     private final MemberEsRepository memberEsRepository;
+    private final PostEsRepository postEsRepository;
+    private final ElasticsearchClient elasticsearchClient;
+
+    @Scheduled(fixedDelay = 600000)
+    public void memberSync() throws IOException {
+        List<Member> members = memberRepository.findAllByStatus(MemberStatus.ACTIVE);
+
+        List<MemberDocument> documents = members.stream()
+                .map(member -> {
+                    return MemberDocument.builder()
+                            .memberId(member.getMemberId())
+                            .name(member.getName())
+                            .email(member.getEmail())
+                            .build();
+                }).toList();
+
+        BulkRequest.Builder br = new BulkRequest.Builder();
+
+        documents.forEach(doc ->
+                br.operations(op -> op
+                        .index(idx -> idx
+                                .index("member")
+                                .id(doc.getMemberId().toString())
+                                .document(doc)
+                        )
+                )
+        );
+        elasticsearchClient.bulk(br.build());
+        System.out.println("✅Member ES 동기화 완료: " + documents.size() + "건");
+    }
 
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMemberUpdateEvent(MemberUpdatedEvent event) {
         log.info("MemberEventListener handleMemberUpdateEvent");
 
@@ -31,9 +75,10 @@ public class MemberEventListener {
     }
 
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMemberDeletedEvent(MemberDeletedEvent event) {
 
         memberEsRepository.deleteById(event.getMemberId());
+        postEsRepository.deleteByMemberId(event.getMemberId());
     }
 }

--- a/src/main/java/com/sj/Petory/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sj/Petory/domain/member/repository/MemberRepository.java
@@ -1,11 +1,13 @@
 package com.sj.Petory.domain.member.repository;
 
 import com.sj.Petory.domain.member.entity.Member;
+import com.sj.Petory.domain.member.type.MemberStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +19,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    List<Member> findAllByStatus(MemberStatus memberStatus);
 }

--- a/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
+++ b/src/main/java/com/sj/Petory/domain/member/service/MemberService.java
@@ -144,15 +144,8 @@ public class MemberService {
         if (name != null) {
             log.info("DB 저장 직후 afterCommit 등록");
 
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-
-                @Override
-                public void afterCommit() {
-                    log.info("after commit에서 이벤트 발생");
-                    eventPublisher.publishEvent(
-                            new MemberUpdatedEvent(member.getMemberId(), name));
-                }
-            });
+            eventPublisher.publishEvent(
+                    new MemberUpdatedEvent(member.getMemberId(), name));
         }
 
 
@@ -165,14 +158,10 @@ public class MemberService {
 
         validateDeleteMember(member);
 
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                eventPublisher.publishEvent(new MemberDeletedEvent(member.getMemberId()));
-            }
-        });
+        member.softDelete();
 
-        member.updateStatus(MemberStatus.DELETED);
+        eventPublisher.publishEvent(
+                new MemberDeletedEvent(member.getMemberId()));
 
         return true;
     }

--- a/src/main/java/com/sj/Petory/domain/post/PostSyncScheduler.java
+++ b/src/main/java/com/sj/Petory/domain/post/PostSyncScheduler.java
@@ -3,35 +3,45 @@ package com.sj.Petory.domain.post;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import com.sj.Petory.domain.post.comment.CommentRepository;
+import com.sj.Petory.domain.post.comment.CommentStatus;
 import com.sj.Petory.domain.post.entity.Post;
 import com.sj.Petory.domain.post.entity.PostDocument;
+import com.sj.Petory.domain.post.event.PostDeletedEvent;
+import com.sj.Petory.domain.post.event.PostUpdatedEvent;
+import com.sj.Petory.domain.post.repository.PostEsRepository;
 import com.sj.Petory.domain.post.repository.PostRepository;
 import com.sj.Petory.domain.post.sympathy.SympathyRepository;
 import com.sj.Petory.domain.post.type.PostStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.io.IOException;
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class PostSyncScheduler {
 
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final SympathyRepository sympathyRepository;
     private final ElasticsearchClient elasticsearchClient;
+    private final PostEsRepository postEsRepository;
 
     @Scheduled(fixedDelay = 600000)
     public void postSync() throws IOException {
         List<Post> posts = postRepository.findAllByStatus(PostStatus.ACTIVE);
 
         List<PostDocument> documents = posts.stream()
-                .filter(post -> PostStatus.ACTIVE.equals(post.getStatus()))
                 .map(post -> {
-                    long commentCount = commentRepository.countAllByPost(post);
+                    long commentCount = commentRepository.countAllByPostAndStatus(post, CommentStatus.ACTIVE);
                     long sympathyCount = sympathyRepository.countAllByPost(post);
 
                     return PostDocument.builder()
@@ -60,6 +70,26 @@ public class PostSyncScheduler {
         );
 
         elasticsearchClient.bulk(br.build());
-        System.out.println("✅ ES 동기화 완료: " + documents.size() + "건");
+        System.out.println("✅Post ES 동기화 완료: " + documents.size() + "건");
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePostUpdateEvent(PostUpdatedEvent event) {
+        log.info("PostEventListener handlePostUpdateEvent");
+
+        postEsRepository.findById(event.getPostId())
+                .ifPresent(doc -> {
+                    PostDocument updatedDoc = doc.updatePost(event);
+                    postEsRepository.save(updatedDoc);
+                });
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePostDeleteEvent(PostDeletedEvent event) {
+        log.info("PostEventListener handlePostDeleteEvent");
+
+        postEsRepository.deleteById(event.getPostId());
     }
 }

--- a/src/main/java/com/sj/Petory/domain/post/comment/Comment.java
+++ b/src/main/java/com/sj/Petory/domain/post/comment/Comment.java
@@ -34,7 +34,8 @@ public class Comment {
     @Enumerated(EnumType.STRING)
     private CommentStatus status;
 
-    public void updateStatus(CommentStatus status) {
-        this.status = status;
+    public void softDelete() {
+
+        this.status = CommentStatus.DELETED;
     }
 }

--- a/src/main/java/com/sj/Petory/domain/post/comment/CommentRepository.java
+++ b/src/main/java/com/sj/Petory/domain/post/comment/CommentRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    long countAllByPost(Post post);
+    long countAllByPostAndStatus(Post post, CommentStatus commentStatus);
 }

--- a/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
+++ b/src/main/java/com/sj/Petory/domain/post/controller/PostController.java
@@ -8,6 +8,7 @@ import com.sj.Petory.domain.post.dto.PostSearchResponse;
 import com.sj.Petory.domain.post.dto.UpdatePostRequest;
 import com.sj.Petory.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,9 +33,9 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PostListResponse>> getPostList() {
+    public ResponseEntity<List<PostListResponse>> getPostList(Pageable pageable) {
 
-        return ResponseEntity.ok(postService.getPostList());
+        return ResponseEntity.ok(postService.getPostList(pageable));
     }
 
     @PatchMapping(path = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/sj/Petory/domain/post/dto/CreatePostRequest.java
+++ b/src/main/java/com/sj/Petory/domain/post/dto/CreatePostRequest.java
@@ -7,6 +7,7 @@ import com.sj.Petory.domain.post.type.PostStatus;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -19,7 +20,7 @@ public class CreatePostRequest {
     private Long categoryId;
     private String title;
     private String content;
-    private List<MultipartFile> image;
+    private List<MultipartFile> image = new ArrayList<>();
 
     public Post toEntity(Member member, PostCategory postCategory) {
         return Post.builder()

--- a/src/main/java/com/sj/Petory/domain/post/entity/Post.java
+++ b/src/main/java/com/sj/Petory/domain/post/entity/Post.java
@@ -108,4 +108,9 @@ public class Post {
                 .categoryId(this.getPostCategory().getPostCategoryId())
                 .build();
     }
+
+    public void softDelete() {
+
+        this.status = PostStatus.DELETED;
+    }
 }

--- a/src/main/java/com/sj/Petory/domain/post/entity/Post.java
+++ b/src/main/java/com/sj/Petory/domain/post/entity/Post.java
@@ -8,6 +8,7 @@ import com.sj.Petory.domain.post.type.PostStatus;
 import io.micrometer.common.util.StringUtils;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -48,6 +49,7 @@ public class Post {
     @Column(name = "post_content")
     private String postContent;
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostImage> postImageList = new ArrayList<>();
 

--- a/src/main/java/com/sj/Petory/domain/post/entity/PostDocument.java
+++ b/src/main/java/com/sj/Petory/domain/post/entity/PostDocument.java
@@ -1,6 +1,7 @@
 package com.sj.Petory.domain.post.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sj.Petory.domain.post.event.PostUpdatedEvent;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -34,4 +36,19 @@ public class PostDocument {
 
     private Long commentCount;
     private Long sympathyCount;
+
+    public PostDocument updatePost(PostUpdatedEvent event) {
+
+        if (StringUtils.hasText(event.getTitle())) {
+            this.title = event.getTitle();
+        }
+        if (StringUtils.hasText(event.getContent())) {
+            this.content = event.getContent();
+        }
+        if (event.getCategoryId() != null) {
+            this.categoryId = event.getCategoryId();
+        }
+
+        return this;
+    }
 }

--- a/src/main/java/com/sj/Petory/domain/post/event/PostDeletedEvent.java
+++ b/src/main/java/com/sj/Petory/domain/post/event/PostDeletedEvent.java
@@ -1,0 +1,12 @@
+package com.sj.Petory.domain.post.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostDeletedEvent {
+
+    private final Long postId;
+
+}

--- a/src/main/java/com/sj/Petory/domain/post/event/PostUpdatedEvent.java
+++ b/src/main/java/com/sj/Petory/domain/post/event/PostUpdatedEvent.java
@@ -1,0 +1,19 @@
+package com.sj.Petory.domain.post.event;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Getter
+@RequiredArgsConstructor
+public class PostUpdatedEvent {
+
+    private final Long postId;
+
+    private final String title;
+    private final String content;
+
+    private final Long categoryId;
+
+}

--- a/src/main/java/com/sj/Petory/domain/post/repository/PostEsRepository.java
+++ b/src/main/java/com/sj/Petory/domain/post/repository/PostEsRepository.java
@@ -4,4 +4,5 @@ import com.sj.Petory.domain.post.entity.PostDocument;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface PostEsRepository extends ElasticsearchRepository<PostDocument, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/sj/Petory/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/sj/Petory/domain/post/repository/PostRepository.java
@@ -19,9 +19,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByMember(Member member, Pageable pageable);
 
-    @EntityGraph(attributePaths = {"member", "postImageList"})
-    List<Post> findByStatus(PostStatus postStatus);
-
+    @EntityGraph(attributePaths = {"member"})
+    Page<Post> findByStatus(PostStatus postStatus, Pageable pageble);
 
     boolean existsByPostIdAndMember(long postId, Member member);
 

--- a/src/main/java/com/sj/Petory/domain/post/service/PostService.java
+++ b/src/main/java/com/sj/Petory/domain/post/service/PostService.java
@@ -31,6 +31,7 @@ import com.sj.Petory.exception.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,9 +98,9 @@ public class PostService {
                 .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
-    public List<PostListResponse> getPostList() {
+    public List<PostListResponse> getPostList(Pageable pageable) {
 
-        return postRepository.findByStatus(PostStatus.ACTIVE).stream()
+        return postRepository.findByStatus(PostStatus.ACTIVE, pageable).stream()
                 .map(post -> PostListResponse.builder()
                         .member(post.getMember().toPostMemberDto())
                         .post(post.toDto())

--- a/src/main/java/com/sj/Petory/domain/post/service/PostService.java
+++ b/src/main/java/com/sj/Petory/domain/post/service/PostService.java
@@ -5,8 +5,6 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sj.Petory.common.s3.AmazonS3Service;
 import com.sj.Petory.domain.member.dto.MemberAdapter;
 import com.sj.Petory.domain.member.entity.Member;
@@ -19,6 +17,8 @@ import com.sj.Petory.domain.post.entity.Post;
 import com.sj.Petory.domain.post.entity.PostCategory;
 import com.sj.Petory.domain.post.entity.PostDocument;
 import com.sj.Petory.domain.post.entity.PostImage;
+import com.sj.Petory.domain.post.event.PostDeletedEvent;
+import com.sj.Petory.domain.post.event.PostUpdatedEvent;
 import com.sj.Petory.domain.post.repository.PostCategoryRepository;
 import com.sj.Petory.domain.post.repository.PostEsRepository;
 import com.sj.Petory.domain.post.repository.PostImageRepository;
@@ -31,6 +31,7 @@ import com.sj.Petory.exception.type.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.stereotype.Service;
@@ -54,8 +55,8 @@ public class PostService {
     private final CommentRepository commentRepository;
     private final SympathyRepository sympathyRepository;
     private final PostEsRepository postEsRepository;
-    private final ElasticsearchOperations elasticsearchOperations;
     private final ElasticsearchClient elasticsearchClient;
+    private final ApplicationEventPublisher eventPublisher;
 
 
     @Transactional
@@ -108,7 +109,7 @@ public class PostService {
                                 post.getPostImageList().stream()
                                         .map(PostImage::toDto)
                                         .toList())
-                        .commentTotal(commentRepository.countAllByPost(post))
+                        .commentTotal(commentRepository.countAllByPostAndStatus(post, CommentStatus.ACTIVE))
                         .sympathyTotal(sympathyRepository.countAllByPost(post))
                         .build()
                 ).collect(Collectors.toList());
@@ -154,6 +155,13 @@ public class PostService {
                             });
         }
 
+        eventPublisher.publishEvent(
+                new PostUpdatedEvent(
+                        post.getPostId(),
+                        post.getPostTitle(),
+                        post.getPostContent(),
+                        post.getPostCategory().getPostCategoryId()));
+
         return true;
     }
 
@@ -178,11 +186,13 @@ public class PostService {
 
         validatePostMember(post, member);
 
-        post.setStatus(PostStatus.DELETED);
+        post.softDelete();
 
-        for (Comment comment : post.getCommentList()) {
-            comment.updateStatus(CommentStatus.DELETED);
-        }
+        post.getCommentList().forEach(Comment::softDelete);
+
+        eventPublisher.publishEvent(
+                new PostDeletedEvent(post.getPostId()));
+
         return true;
     }
 
@@ -239,7 +249,7 @@ public class PostService {
                             .orElse(null);
 
                     PostSearchResponse.Post post = PostSearchResponse.toPostResponse(postEntity);
-                    post.setCommentTotal(commentRepository.countAllByPost(postEntity));
+                    post.setCommentTotal(commentRepository.countAllByPostAndStatus(postEntity, CommentStatus.ACTIVE));
                     post.setSympathyTotal(sympathyRepository.countAllByPost(postEntity));
 
                     Map<String, List<String>> highlight = hit.highlight();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

***게시글 목록 API*** 
 변경사항 : 
 1. 게시글 목록 API의 요청 파라미터에 Pageable을 추가하고 응답으로 Page형태를 내려주는 메소드로 변경 
  -> 무한 스크롤 구현하기 위함
 2. Post엔티티에 연관된 Member와 PostImage 엔티티의 join 방식을 기존 @EntityGraph에서 PostImage만 분리하여 BatchSize  사용
  -> Post는 Member와는 N : 1관계라 @EntityGraph을 사용해도 되지만 PostImage와는 1 : N 관계여서 Pageable인자로 limit같은 옵션들이 걸려있을경우 데이터가 중복되거나 누락되는 경우가 발생할 수 있기 때문에 PostImage를 BatchSize를 사용

*** 회원 삭제시 로직*** 
1. 게시글, 댓글 DB에 soft Delete
2. 이벤트 발생시켜 member, post document ES에서 삭제

*** 게시글 삭제시 로직*** 
1. 게시글, 댓글 DB에서 soft Delete 
2. 이벤트 발생시켜 post document ES에서 삭제 

*** 회원 삭제시 Event 발생 로직 수정***
기존
 : 서비스 단에서 TransactionSynchronizationManager.registerSynchronization @afterCommit이용해 이벤트 발행
 : 이벤트 리스너에서 @Async @EventListener 이용

 변경
 : 서비스 단에서 eventPublisher.publishEvent(new XxxEvent(...)) 호출
 : 이벤트 리스너에서 발행 시점 제어 @TransactionalEventListener(phase = AFTER_COMMIT)으로 트랜잭션 커밋 이후에 이벤트 발생하도록

=> 무조건 트랜잭션 커밋 이후에 발생하는 이벤트 로직이기에 위와 같이 수정하여 트랜잭션의 일관성을 강력하게 보장하고, 코드의 가독성 및 유지보수성을 향상시키도록 했습니다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
