### PR TITLE
[Feat] 도커 기반 환경 변화에 따른 설정파일 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ replay_pid*
 
 application.yml
 *.yml
+!docker-compose.prod.yml
 open-api-3.0.1.json
 src/main/resources/db/migration/mysql/
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ pipeline {
             steps {
                 // 자격 증명을 사용하여 비공개 저장소에 접근합니다.
                 git branch: 'develop', url: 'https://github.com/SJ-Petory/Petory-BackEnd.git', credentialsId: 'github-credentials'
+
+                sh 'git submodule update --init --recursive'
             }
         }
 
@@ -48,10 +50,8 @@ pipeline {
             steps {
                 echo "===== EC2 서버에 배포합니다 ====="
                 sh """
-                    docker stop petory-backend || true
-                    docker rm petory-backend || true
-                    docker pull ${DOCKER_IMAGE_NAME}:latest
-                    docker run -d -p 8080:8080 --name petory-backend --restart always ${DOCKER_IMAGE_NAME}:latest
+                    docker-compose -f docker-compose.prod.yml pull petory-backend
+                    docker-compose -f docker-compose.prod.yml up -d --force-recreate petory-backend
                 """
                 echo "===== 배포 완료 ====="
             }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  petory-backend:
+    image: sonii26/petory-backend:latest
+    container_name: petory-backend-prod
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      - elasticsearch
+    environment:
+      - SPRING_ELASTICSEARCH_REST_URIS=http://elasticsearch:9200
+      - SPRING_PROFILES_ACTIVE=prod
+    networks:
+      - app-network
+
+  elasticsearch:
+#    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    build: ./elasticsearch
+    container_name: elasticsearch-prod
+    restart: always
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+    volumes:
+      - es-data-prod:/usr/share/elasticsearch/data
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  es-data-prod:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,5 @@
+# docker-compose.yml에 명시된 이미지와 동일한 버전을 사용합니다.
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+
+# nori 형태소 분석기 플러그인을 설치합니다.
+RUN bin/elasticsearch-plugin install analysis-nori

--- a/src/main/java/com/sj/Petory/domain/member/event/MemberEventListener.java
+++ b/src/main/java/com/sj/Petory/domain/member/event/MemberEventListener.java
@@ -42,6 +42,11 @@ public class MemberEventListener {
                             .build();
                 }).toList();
 
+        if (documents.isEmpty()) {
+            System.out.println("✅ Member ES 동기화 대상 없음");
+            return;
+        }
+
         BulkRequest.Builder br = new BulkRequest.Builder();
 
         documents.forEach(doc ->

--- a/src/main/java/com/sj/Petory/domain/post/PostSyncScheduler.java
+++ b/src/main/java/com/sj/Petory/domain/post/PostSyncScheduler.java
@@ -55,6 +55,10 @@ public class PostSyncScheduler {
                             .build();
                 }).toList();
 
+        if (documents.isEmpty()) {
+            System.out.println("✅ POST ES 동기화 대상 없음");
+            return;
+        }
         // Bulk Update
         BulkRequest.Builder br = new BulkRequest.Builder();
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
Dockerfile
spring boot 어플리케이션 이미지화 코드

docker-compose.prod.yml 추가
배포 환경에서 elasticsearch도 함께 올라가야하기에 docker-compose를 통하여 스프링부트 웹 프로젝트파일과 함께 관리하도록 함

Jenkinsfile
기존 일일히 docker 명령어를 입력해 스프링부트를 실행시키던 것에서 docker compose를 실행시키는 로직으로 간소화됨.
    docker-compose -f docker-compose.prod.yml pull petory-backend
   -> 도커 허브에서 항상 최신 버전의 코드를 받아오게 함
    docker-compose -f docker-compose.prod.yml up -d --force-recreate petory-backend
   -> up 명령어는 설정이 바뀐 컨테이너만 다시 만드는데 이미지만 새로 받았을 뿐 설정파일은 그대로임.
   -> --force-recreate 옵션을 통해 설정이 그대로여도 컨테이너를 강제로 재시작하도록함. 이 설정은  petory-backend에만 적용됨.

깃 서브모듈에 접근해서 설정파일 정보를 불러올 수 있도록 함.

Jenkinsfile
**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
