### PR TITLE
[Feat] 사용자 식별자 받아오는 로직으로 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/sj/Petory/OAuth/RedisConfig.java
+++ b/src/main/java/com/sj/Petory/OAuth/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.sj.Petory.OAuth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // Key는 문자열로 저장
+        template.setKeySerializer(new StringRedisSerializer());
+
+        // Value는 JSON으로 직렬화하여 저장 (DTO 객체 저장 가능)
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/sj/Petory/OAuth/controller/KakaoLoginController.java
+++ b/src/main/java/com/sj/Petory/OAuth/controller/KakaoLoginController.java
@@ -1,6 +1,7 @@
 package com.sj.Petory.OAuth.controller;
 
 import com.sj.Petory.OAuth.dto.ExtraUserInfo;
+import com.sj.Petory.OAuth.dto.KakaoAuthInfo;
 import com.sj.Petory.OAuth.service.KakaoLoginService;
 import com.sj.Petory.domain.member.dto.SignIn;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,19 +23,16 @@ public class KakaoLoginController {
             , HttpServletResponse response) throws IOException {
 
         System.out.println(code);
-        String accessTokenFromKakao = kakaoLoginService.getAccessTokenFromKakao(code);
-
-        String redirectUrl = "http://43.202.195.199/inputInfo?token=" + accessTokenFromKakao;
+        String redirectUrl = kakaoLoginService.getAccessTokenFromKakao(code);
 
         response.sendRedirect(redirectUrl);
     }
 
     @PostMapping("/oauth/kakao/extraInfo")
     public ResponseEntity<SignIn.Response> kakaoExtraInfo(
-            @RequestHeader("Authorization") String accessToken
-            , @RequestBody @Valid ExtraUserInfo extraUserInfo) {
+            @RequestBody @Valid ExtraUserInfo extraUserInfo) {
 
         return ResponseEntity.ok(
-                kakaoLoginService.kakaoExtraInfo(accessToken, extraUserInfo));
+                kakaoLoginService.kakaoExtraInfo(extraUserInfo));
     }
 }

--- a/src/main/java/com/sj/Petory/OAuth/dto/CachedKakaoInfo.java
+++ b/src/main/java/com/sj/Petory/OAuth/dto/CachedKakaoInfo.java
@@ -1,0 +1,16 @@
+package com.sj.Petory.OAuth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CachedKakaoInfo {
+    private String sub;
+    private String name;
+    private String image;
+}

--- a/src/main/java/com/sj/Petory/OAuth/dto/ExtraUserInfo.java
+++ b/src/main/java/com/sj/Petory/OAuth/dto/ExtraUserInfo.java
@@ -11,6 +11,9 @@ import lombok.*;
 public class ExtraUserInfo {
 
     @NotBlank
+    private String registerId;
+
+    @NotBlank
     private String email;
     @NotBlank
     private String phone;

--- a/src/main/java/com/sj/Petory/OAuth/dto/KakaoAuthInfo.java
+++ b/src/main/java/com/sj/Petory/OAuth/dto/KakaoAuthInfo.java
@@ -1,0 +1,15 @@
+package com.sj.Petory.OAuth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoAuthInfo {
+    private String accessToken;
+    private String sub;
+}

--- a/src/main/java/com/sj/Petory/OAuth/dto/TokenResponseFromKakao.java
+++ b/src/main/java/com/sj/Petory/OAuth/dto/TokenResponseFromKakao.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KakaoTokenResponse {
+public class TokenResponseFromKakao {
 
     @JsonProperty("token_type")
     public String tokenType;

--- a/src/main/java/com/sj/Petory/OAuth/service/KakaoLoginService.java
+++ b/src/main/java/com/sj/Petory/OAuth/service/KakaoLoginService.java
@@ -1,8 +1,8 @@
 package com.sj.Petory.OAuth.service;
 
-import com.sj.Petory.OAuth.dto.ExtraUserInfo;
-import com.sj.Petory.OAuth.dto.KakaoTokenResponse;
-import com.sj.Petory.OAuth.dto.UserInfoResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sj.Petory.OAuth.dto.*;
 import com.sj.Petory.common.es.MemberEsRepository;
 import com.sj.Petory.common.s3.AmazonS3Service;
 import com.sj.Petory.domain.member.dto.SignIn;
@@ -14,9 +14,17 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Service
@@ -33,10 +41,11 @@ public class KakaoLoginService {
     private final MemberRepository memberRepository;
     private final JwtUtils jwtUtils;
     private final AmazonS3Service amazonS3Service;
+    private final RedisTemplate<String, Object> redisTemplate; // Redis 주입!
 
-    public String getAccessTokenFromKakao(String code) {
+    public String getAccessTokenFromKakao(String code) throws JsonProcessingException {
 
-        KakaoTokenResponse kakaoTokenResponseDto =
+        TokenResponseFromKakao tokenResponse =
                 WebClient.create(KAUTH_TOKEN_URL_HOST).post()
                         .uri(uriBuilder -> uriBuilder
                                 .scheme("https")
@@ -50,36 +59,111 @@ public class KakaoLoginService {
                         //TODO : Custom Exception
 //                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
 //                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
-                        .bodyToMono(KakaoTokenResponse.class)
+                        .bodyToMono(TokenResponseFromKakao.class)
                         .block();
 
 
-        log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
-        log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
+        log.info(" [Kakao Service] Access Token ------> {}", tokenResponse.getAccessToken());
+        log.info(" [Kakao Service] Refresh Token ------> {}", tokenResponse.getRefreshToken());
         //제공 조건: OpenID Connect가 활성화 된 앱의 토큰 발급 요청인 경우 또는 scope에 openid를 포함한 추가 항목 동의 받기 요청을 거친 토큰 발급 요청인 경우
-        log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDto.getIdToken());
-        log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDto.getScope());
+        log.info(" [Kakao Service] Id Token ------> {}", tokenResponse.getIdToken());
+        log.info(" [Kakao Service] Scope ------> {}", tokenResponse.getScope());
 
-        return kakaoTokenResponseDto.getAccessToken();
+        String idToken = tokenResponse.getIdToken();
+        //토큰 파싱
+        // 1. 토큰 디코딩
+        String[] token = idToken.split("\\.");
+        Base64.Decoder decoder = Base64.getUrlDecoder();
+        String payloadJson = new String(decoder.decode(token[1]));
+
+        System.out.println("디코딩 된 JSON : " + payloadJson);
+
+        // 2. Payload 값 추출
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> claims = mapper.readValue(payloadJson, Map.class);
+
+        String sub = (String) claims.get("sub");
+
+        System.out.println("회원번호(sub): " + sub);
+
+        Optional<Member> newMember = memberRepository.findByProviderId(sub);
+
+        if (newMember.isPresent()) { //이미 존재하면
+            //로그인 완 토큰 발급
+            Member member = newMember.get();
+            String accessToken = jwtUtils.generateToken(member.getEmail(), "ATK", member.getRole().getKey());
+            String refreshToken = jwtUtils.generateToken(member.getEmail(), "RTK", member.getRole().getKey());
+
+            return UriComponentsBuilder.fromUriString("/mainPage")
+                    .queryParam("accessToken", accessToken)
+                    .queryParam("refreshToken", refreshToken)
+                    .build().toUriString();
+        } else { //존재하지 않으면 기존 회원과 연결 or 회원가입 로직
+                //을 할려면 추가 정보(이메일, 폰번호)가 있어야 한다
+            String registerId = UUID.randomUUID().toString();
+
+            UserInfoResponse userInfoResponse = WebClient.create(KAUTH_USER_URL_HOST).get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .path("/v2/user/me")
+                            .build()
+                    )
+                    .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                    .header("Authorization", "Bearer " + tokenResponse.getAccessToken())
+                    .retrieve()
+                    .bodyToMono(UserInfoResponse.class)
+                    .block();
+
+            UserInfoResponse.KakaoAcount.ProfileInfo profile
+                    = userInfoResponse.getKakaoAcount().getProfile();
+
+            CachedKakaoInfo cachedInfo = CachedKakaoInfo.builder()
+                    .sub(sub)
+                    .name(profile.getNickName())
+                    .image(amazonS3Service.uploadImageforKakao(
+                            profile.getProfileImageUrl()))
+                    .build();
+
+            redisTemplate.opsForValue().set(
+                    registerId,
+                    cachedInfo,
+                    30,
+                    TimeUnit.MINUTES
+            );
+            return UriComponentsBuilder.fromUriString("https://petory.site/inputInfo")
+                    .queryParam("registerId", registerId)
+                    .build().toUriString();
+        }
     }
 
     public SignIn.Response kakaoExtraInfo(
-            final String accessToken
-            , final ExtraUserInfo extraUserInfo) {
+            final ExtraUserInfo extraUserInfo) {
 
-        UserInfoResponse userInfoResponse = WebClient.create(KAUTH_USER_URL_HOST).get()
-                .uri(uriBuilder -> uriBuilder
-                        .scheme("https")
-                        .path("/v2/user/me")
-                        .build()
-                )
-                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .bodyToMono(UserInfoResponse.class)
-                .block();
+        String key = extraUserInfo.getRegisterId();
+        CachedKakaoInfo kakaoInfo = (CachedKakaoInfo) redisTemplate.opsForValue().get(key);
 
-        Member member = memberRepository.save(findOrCreateMember(userInfoResponse, extraUserInfo));
+        if (kakaoInfo == null) {
+            throw new RuntimeException("유효시간이 만료되었거나 잘못된 요청입니다.");
+        }
+        Optional<Member> existingMember = memberRepository.findByEmail(request.getEmail());
+
+        Member member;
+        if (existingMember.isPresent()) {
+            member = existingMember.get();
+            member.updateSocialId(kakaoInfo.getSub()); // 소셜 ID 연동
+        } else {
+            member = Member.builder()
+                    .email(request.getEmail())
+                    .phone(request.getPhone())
+                    .nickname(kakaoInfo.getNickname()) // Redis에 있던 닉네임 사용
+                    .socialId(kakaoInfo.getSub())      // Redis에 있던 Sub 사용
+                    .role(Role.USER)
+                    .build();
+            memberRepository.save(member);
+        }
+
+        // 3. 사용한 임시 데이터 삭제 (선택 사항 - TTL 있어서 굳이 안 해도 됨)
+        redisTemplate.delete(key);        Member member = memberRepository.save(findOrCreateMember(userInfoResponse, extraUserInfo));
         memberEsRepository.save(member.toDocument());
 
         return SignIn.Response.toResponse(

--- a/src/main/java/com/sj/Petory/OAuth/type/SocialType.java
+++ b/src/main/java/com/sj/Petory/OAuth/type/SocialType.java
@@ -1,0 +1,5 @@
+package com.sj.Petory.OAuth.type;
+
+public enum SocialType {
+    KAKAO
+}

--- a/src/main/java/com/sj/Petory/domain/member/entity/Member.java
+++ b/src/main/java/com/sj/Petory/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.sj.Petory.domain.member.entity;
 
+import com.sj.Petory.OAuth.type.SocialType;
 import com.sj.Petory.common.es.MemberDocument;
 import com.sj.Petory.domain.friend.dto.MemberSearchResponse;
 import com.sj.Petory.domain.member.dto.PostMemberInfo;
@@ -48,6 +49,13 @@ public class Member {
 
     @Column(name = "phone")
     private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider")
+    private SocialType provider;
+
+    @Column(name = "provider_id")
+    private String providerId;
 
     @Column(name = "image")
     private String image;

--- a/src/main/java/com/sj/Petory/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sj/Petory/domain/member/repository/MemberRepository.java
@@ -21,4 +21,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByStatus(MemberStatus memberStatus);
 
     Optional<Member> findByMemberIdAndRole(long id, Role role);
+
+    Optional<Member> findByProviderId(String providerId);
 }

--- a/src/main/java/com/sj/Petory/security/JwtUtils.java
+++ b/src/main/java/com/sj/Petory/security/JwtUtils.java
@@ -101,7 +101,7 @@ public class JwtUtils {
         return parseClaims(token).getSubject();
     }
 
-    private Claims parseClaims(String token) {
+    public Claims parseClaims(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey)
                 .parseClaimsJws(token).getBody();

--- a/src/main/resources/db/migration/mariaDB/V34__add_column_provider_and_providerId.sql
+++ b/src/main/resources/db/migration/mariaDB/V34__add_column_provider_and_providerId.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member add column 	`provider` VARCHAR(10) NULL;
+ALTER TABLE member add column  `provider_id` VARCHAR(50)    NULL;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
기존 카카오 로그인 개발 버전 이메일 미제공 문제로 사용자를 식별하기 위해 불가피하게 매번 추가정보 (이메일, 전화번호)를 입력해야하는 로직을 개선

카카오에서 내려주는 ID토큰 안에 사용자를 식별할 수 있는 회원정보가 있음을 알게되어 해당 식별자로 회원을 구분하는 로직으로 변경하는 중

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
