### PR TITLE
[Feat] 카카오 로그인 토큰 전달 방식 보안 강화 (URL 노출 방지)

### DIFF
--- a/src/main/java/com/sj/Petory/OAuth/controller/KakaoLoginController.java
+++ b/src/main/java/com/sj/Petory/OAuth/controller/KakaoLoginController.java
@@ -1,7 +1,6 @@
 package com.sj.Petory.OAuth.controller;
 
 import com.sj.Petory.OAuth.dto.ExtraUserInfo;
-import com.sj.Petory.OAuth.dto.KakaoAuthInfo;
 import com.sj.Petory.OAuth.service.KakaoLoginService;
 import com.sj.Petory.domain.member.dto.SignIn;
 import jakarta.servlet.http.HttpServletResponse;
@@ -11,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +34,12 @@ public class KakaoLoginController {
 
         return ResponseEntity.ok(
                 kakaoLoginService.kakaoExtraInfo(extraUserInfo));
+    }
+
+    @PostMapping("/oauth/token/issue")
+    public ResponseEntity<SignIn.Response> issueToken(@RequestBody Map<String, String> request) {
+
+        String code = request.get("code");
+        return ResponseEntity.ok(kakaoLoginService.issueToken(code));
     }
 }

--- a/src/main/java/com/sj/Petory/OAuth/dto/TokenInfo.java
+++ b/src/main/java/com/sj/Petory/OAuth/dto/TokenInfo.java
@@ -1,0 +1,8 @@
+package com.sj.Petory.OAuth.dto;
+
+
+public record TokenInfo (
+        String accessToken,
+        String refreshToken
+){
+}

--- a/src/main/java/com/sj/Petory/OAuth/service/KakaoLoginService.java
+++ b/src/main/java/com/sj/Petory/OAuth/service/KakaoLoginService.java
@@ -40,8 +40,8 @@ public class KakaoLoginService {
     @Value("${app.front-url}") // 설정 파일에서 주소 가져오기
     private String frontUrl;
 
-    private final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
-    private final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+    private final static String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
+    private final static String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
 
     private final MemberRepository memberRepository;
     private final JwtUtils jwtUtils;
@@ -68,6 +68,10 @@ public class KakaoLoginService {
                         .block();
 
 
+        if (tokenResponse == null) {
+            throw new RuntimeException("카카오 응답이 없습니다.");
+        }
+
         log.info(" [Kakao Service] Access Token ------> {}", tokenResponse.getAccessToken());
         log.info(" [Kakao Service] Refresh Token ------> {}", tokenResponse.getRefreshToken());
         //제공 조건: OpenID Connect가 활성화 된 앱의 토큰 발급 요청인 경우 또는 scope에 openid를 포함한 추가 항목 동의 받기 요청을 거친 토큰 발급 요청인 경우
@@ -85,6 +89,8 @@ public class KakaoLoginService {
 
         // 2. Payload 값 추출
         ObjectMapper mapper = new ObjectMapper();
+
+        @SuppressWarnings("unchecked")
         Map<String, Object> claims = mapper.readValue(payloadJson, Map.class);
 
         String sub = (String) claims.get("sub");
@@ -93,20 +99,30 @@ public class KakaoLoginService {
 
         Optional<Member> newMember = memberRepository.findByProviderId(sub);
 
+        String registerId = UUID.randomUUID().toString();
+
         if (newMember.isPresent()) { //이미 존재하면
             //로그인 완 토큰 발급
-            System.out.println("랄라 이미 가입");
+
             Member member = newMember.get();
             String accessToken = jwtUtils.generateToken(member.getEmail(), "ATK", member.getRole().getKey());
             String refreshToken = jwtUtils.generateToken(member.getEmail(), "RTK", member.getRole().getKey());
 
+            TokenInfo tokenInfo = new TokenInfo(accessToken, refreshToken);
+
+            redisTemplate.opsForValue().set(
+                    registerId,
+                    tokenInfo,
+                    30,
+                    TimeUnit.MINUTES
+            );
+
             return UriComponentsBuilder.fromUriString(frontUrl + "/mainPage")
-                    .queryParam("accessToken", accessToken)
-                    .queryParam("refreshToken", refreshToken)
+                    .queryParam("code", registerId)
+                    .queryParam("status", "login")
                     .build().toUriString();
         } else { //존재하지 않으면 기존 회원과 연결 or 회원가입 로직
             //을 할려면 추가 정보(이메일, 폰번호)가 있어야 한다
-            String registerId = UUID.randomUUID().toString();
 
             UserInfoResponse userInfoResponse = WebClient.create(KAUTH_USER_URL_HOST).get()
                     .uri(uriBuilder -> uriBuilder
@@ -119,6 +135,10 @@ public class KakaoLoginService {
                     .retrieve()
                     .bodyToMono(UserInfoResponse.class)
                     .block();
+
+            if (userInfoResponse == null) {
+                throw new RuntimeException("카카오 유저 정보를 가져오지 못했습니다.");
+            }
 
             UserInfoResponse.KakaoAcount.ProfileInfo profile
                     = userInfoResponse.getKakaoAcount().getProfile();
@@ -138,6 +158,7 @@ public class KakaoLoginService {
             );
             return UriComponentsBuilder.fromUriString(frontUrl + "/inputInfo")
                     .queryParam("registerId", registerId)
+                    .queryParam("status", "register")
                     .build().toUriString();
         }
     }
@@ -153,12 +174,12 @@ public class KakaoLoginService {
 
         CachedKakaoInfo kakaoInfo = (CachedKakaoInfo) redisTemplate.opsForValue().get(key);
 
-        if (memberRepository.existsByProviderId(Objects.requireNonNull(kakaoInfo).getSub())) {
-            throw new OAuthException(ErrorCode.OAUTH_MEMBER_DUPLICATED);
+        if (kakaoInfo == null) {
+            throw new OAuthException(ErrorCode.INVALID_REGISTER_KEY);
         }
 
-        if (kakaoInfo == null) {
-            throw new RuntimeException("유효시간이 만료되었거나 잘못된 요청입니다.");
+        if (memberRepository.existsByProviderId(kakaoInfo.getSub())) {
+            throw new OAuthException(ErrorCode.OAUTH_MEMBER_DUPLICATED);
         }
 
         Member member = memberRepository.save(findOrCreateMember(extraUserInfo, kakaoInfo));
@@ -166,7 +187,6 @@ public class KakaoLoginService {
 
         memberEsRepository.save(member.toDocument());
 
-        // 3. 사용한 임시 데이터 삭제 (선택 사항 - TTL 있어서 굳이 안 해도 됨)
         redisTemplate.delete(key);
 
         return SignIn.Response.toResponse(
@@ -191,5 +211,26 @@ public class KakaoLoginService {
                 .status(MemberStatus.ACTIVE)
                 .role(Role.USER)
                 .build();
+    }
+
+    public SignIn.Response issueToken(String code) {
+
+        Object data = redisTemplate.opsForValue().get(code);
+
+        if (data == null) {
+            throw new OAuthException(ErrorCode.INVALID_CODE);
+        }
+
+        TokenInfo tokenInfo;
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            tokenInfo = mapper.convertValue(data, TokenInfo.class);
+        } catch (IllegalArgumentException e) {
+            throw new OAuthException(ErrorCode.INVALID_OAUTH_DATA);
+        }
+
+        redisTemplate.delete(code);
+
+        return SignIn.Response.toResponse(tokenInfo.accessToken(), tokenInfo.refreshToken());
     }
 }

--- a/src/main/java/com/sj/Petory/config/SecurityConfig.java
+++ b/src/main/java/com/sj/Petory/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                                         , "/api/pets/species", "/api/pets/breed/**"
                                         , "/api/h2-console/**"
                                         , "/docs/**", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                                .requestMatchers("/oauth/kakao/**").permitAll()
+                                .requestMatchers("/oauth/**").permitAll()
                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                 .requestMatchers(HttpMethod.POST, "/api/community/category").hasRole("ADMIN")
                                 .requestMatchers(HttpMethod.DELETE, "/api/community/category").hasRole("ADMIN")

--- a/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
+++ b/src/main/java/com/sj/Petory/exception/type/ErrorCode.java
@@ -76,7 +76,10 @@ public enum ErrorCode {
     SYMPATHY_NOT_FOUND("공감 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     NOT_ADMIN_USER("관리자만 접근 가능합니다.", HttpStatus.BAD_REQUEST),
-    OAUTH_MEMBER_DUPLICATED("동일한 식별자로 소셜로그인 한 계정이 있습니다.",HttpStatus.BAD_REQUEST);
+    OAUTH_MEMBER_DUPLICATED("동일한 식별자로 소셜로그인 한 계정이 있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CODE("유효시간이 만료되었거나 잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_OAUTH_DATA("처리할 수 없는 데이터 입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_REGISTER_KEY("유효시간이 만료되었거나 잘못된 요청입니다.", HttpStatus.BAD_REQUEST);
 
     private final String description;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 리다이렉트 URL에 토큰 직접 노출 대신 Redis 기반의 Auth Code 전달로 변경
- Auth Code를 통한 토큰 교환 API (POST /oauth/token/issue) 추가

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
