### PR TITLE
[Feat] Image url을 public url로 생성하여 저장하는 로직으로 수정

### DIFF
--- a/src/main/java/com/sj/Petory/common/s3/AmazonS3Service.java
+++ b/src/main/java/com/sj/Petory/common/s3/AmazonS3Service.java
@@ -35,6 +35,13 @@ public class AmazonS3Service {
     @Value("${cloud.aws.s3.bucketName}")
     private String bucketName;
 
+    @Value("${cloud.aws.s3.public-url}")
+    private String publicUrl;
+
+    private String getPublicUrl(String fileName) {
+        return String.format("%s/%s/%s", publicUrl, bucketName, fileName);
+    }
+
     public String uploadImageforKakao(String imageUrl) {
 
         if (StringUtils.isEmpty(imageUrl)) {
@@ -49,7 +56,7 @@ public class AmazonS3Service {
 
             amazonS3.putObject(bucketName, randomFilename, inputStream, metaData);
 
-            return amazonS3.getUrl(bucketName, randomFilename).toString();
+            return getPublicUrl(randomFilename);
 
         } catch (Exception e) {
             throw new S3Exception(IMAGE_UPLOAD_FAIL);
@@ -86,7 +93,7 @@ public class AmazonS3Service {
 
         log.info("File upload Success : " + randomFilename);
 
-        return amazonS3.getUrl(bucketName, randomFilename).toString();
+        return getPublicUrl(randomFilename);
     }
 
     private String generateRandomFilename(String originName) {
@@ -119,7 +126,10 @@ public class AmazonS3Service {
 
     private String extractKeyFromUrl(String imageUrl) throws MalformedURLException {
         URL url = new URL(imageUrl);
-        return url.getPath().substring(1);
+        String path = url.getPath(); // /petory-image/uuid.jpg
+
+        // 경로에서 버킷 이름을 제외한 순수 파일명
+        return path.substring(path.lastIndexOf("/") + 1);
     }
 
     public String updateImage(String oldImageUrl, MultipartFile newImage) {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
기존 사용하던 endpoint로 url을 생성하여 db에 넣어줄 경우 petory-minio는 서버 내부의 컨테이너로 연결되는 주소이기에 정상적으로 사진을 확인할 수 없다. 따라서 이미지 조회 전용 도메인으로 수정하였다.

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
